### PR TITLE
add --timeZoneOffset argument for cwa cwa.gz files; expose csv arguments to python script

### DIFF
--- a/accProcess.py
+++ b/accProcess.py
@@ -35,7 +35,8 @@ def main():
                             metavar='e.g. -180', default=0,
                             type=int, help="""timezone minutes offset induced 
                             by timezone difference from configure timezone and
-                            deployment timezone""")
+                            deployment timezone
+                            (default : %(default)s""")
     parser.add_argument('--startTime',
                             metavar='e.g. 1991-01-01T23:59', default=None,
                             type=str2date, help="""removes data before this
@@ -73,6 +74,30 @@ def main():
                             metavar='True/False', default=False, type=str2bool,
                             help="""Skip filtering stage
                              (default : %(default)s)""")
+    parser.add_argument('--csvStartTime',
+                            metavar='e.g. 1991-01-01T23:59', default=None,
+                            type=str2date, help="""start time for csv file 
+                            when time column is not available
+                            (default : %(default)s)""")
+    parser.add_argument('--csvSampleRate',
+                            metavar='Hz, or samples/second', default=None,
+                            type=float, help="""sample rate for csv file 
+                            when time column is not available (default
+                             : %(default)s)""")
+    parser.add_argument('--csvTimeFormat',
+                            metavar='time format', default=None,
+                            type=str, help="""time format for csv file 
+                            when time column is available (default
+                             : %(default)s)""")                         
+    parser.add_argument('--csvStartRow',
+                            metavar='start row', default=None, type=int,
+                            help="""start row for accelerometer data in csv file (default
+                             : %(default)s, must be an integer)""")                         
+    parser.add_argument('--csvXYZTCols',
+                            metavar='XYZT Cols', default=None,
+                            type=str, help="""index of column positions for XYZT columns, 
+                            e.g. "0,1,2,3" (default
+                             : %(default)s)""")
     # calibration parameters
     parser.add_argument('--skipCalibration',
                             metavar='True/False', default=False, type=str2bool,
@@ -282,7 +307,10 @@ def main():
             npyOutput=args.npyOutput, npyFile=args.npyFile,
             fftOutput=args.fftOutput, startTime=args.startTime,
             endTime=args.endTime, verbose=args.verbose, 
-            timeZoneOffset = args.timeZoneOffset)
+            timeZoneOffset=args.timeZoneOffset,
+            csvStartTime=args.csvStartTime, csvSampleRate=args.csvSampleRate,
+            csvTimeFormat=args.csvTimeFormat, csvStartRow=args.csvStartRow,
+            csvXYZTCols=args.csvXYZTCols)
     else:
         summary['file-name'] = args.epochFile
 

--- a/accProcess.py
+++ b/accProcess.py
@@ -31,6 +31,11 @@ def main():
                             """)
 
     #optional inputs
+    parser.add_argument('--timeZoneOffset',
+                            metavar='e.g. -180', default=0,
+                            type=int, help="""timezone minutes offset induced 
+                            by timezone difference from configure timezone and
+                            deployment timezone""")
     parser.add_argument('--startTime',
                             metavar='e.g. 1991-01-01T23:59', default=None,
                             type=str2date, help="""removes data before this
@@ -276,7 +281,8 @@ def main():
             rawOutput=args.rawOutput, rawFile=args.rawFile,
             npyOutput=args.npyOutput, npyFile=args.npyFile,
             fftOutput=args.fftOutput, startTime=args.startTime,
-            endTime=args.endTime, verbose=args.verbose)
+            endTime=args.endTime, verbose=args.verbose, 
+            timeZoneOffset = args.timeZoneOffset)
     else:
         summary['file-name'] = args.epochFile
 

--- a/accelerometer/device.py
+++ b/accelerometer/device.py
@@ -20,7 +20,8 @@ def processInputFileToEpoch(inputFile, epochFile, stationaryFile, summary,
     useAbs=False, activityClassification=True,
     rawOutput=False, rawFile=None, npyOutput=False, npyFile=None,
     fftOutput=False, startTime=None, endTime=None,
-    verbose=False, timeZoneOffset = 0):
+    verbose=False, timeZoneOffset=0,
+    csvStartTime=None, csvSampleRate=None, csvTimeFormat=None, csvStartRow=None, csvXYZTCols=None):
     """Process raw accelerometer file, writing summary epoch stats to file
 
     This is usually achieved by
@@ -64,7 +65,12 @@ def processInputFileToEpoch(inputFile, epochFile, stationaryFile, summary,
     :param datetime startTime: Remove data before this time in analysis
     :param datetime endTime: Remove data after this time in analysis
     :param bool verbose: Print verbose output
-    :param int timeZoneOffset: timezone difference between configure and deployment
+    :param int timeZoneOffset: timezone difference between configure and deployment (in minutes)
+    :param datetime csvStartTime: start time for csv file when time column is not available
+    :param float csvSampleRate: sample rate for csv file when time column is not available
+    :param str csvTimeFormat: time format for csv file when time column is available
+    :param int csvStartRow: start row for accelerometer data in csv file
+    :param str csvXYZTCols: index of column positions for XYZT columns, e.g. "0,1,2,3"
 
     :return: Raw processing summary values written to dict <summary>
     :rtype: void
@@ -99,6 +105,18 @@ def processInputFileToEpoch(inputFile, epochFile, stationaryFile, summary,
                 "stationaryStd:" + str(staticStdG)]
             if javaHeapSpace:
                 commandArgs.insert(1, javaHeapSpace)
+            if timeZoneOffset:
+                commandArgs.append("timeZoneOffset:" + str(timeZoneOffset))
+            if csvStartTime:
+                commandArgs.append("csvStartTime:" + csvStartTime.strftime("%Y-%m-%dT%H:%M"))
+            if csvSampleRate:
+                commandArgs.append("csvSampleRate:" + str(csvSampleRate))
+            if csvTimeFormat:
+                commandArgs.append("csvTimeFormat:" + str(csvTimeFormat))
+            if csvStartRow:
+                commandArgs.append("csvStartRow:" + str(csvStartRow))
+            if csvXYZTCols:
+                commandArgs.append("csvXYZTCols:" + str(csvXYZTCols))
             # call process to identify stationary epochs
             exitCode = call(commandArgs)
             if exitCode != 0:
@@ -161,6 +179,16 @@ def processInputFileToEpoch(inputFile, epochFile, stationaryFile, summary,
             commandArgs.append("endTime:" + endTime.strftime("%Y-%m-%dT%H:%M"))
         if timeZoneOffset:
             commandArgs.append("timeZoneOffset:" + str(timeZoneOffset))
+        if csvStartTime:
+            commandArgs.append("csvStartTime:" + csvStartTime.strftime("%Y-%m-%dT%H:%M"))
+        if csvSampleRate:
+            commandArgs.append("csvSampleRate:" + str(csvSampleRate))
+        if csvTimeFormat:
+            commandArgs.append("csvTimeFormat:" + str(csvTimeFormat))
+        if csvStartRow:
+            commandArgs.append("csvStartRow:" + str(csvStartRow))
+        if csvXYZTCols:
+            commandArgs.append("csvXYZTCols:" + str(csvXYZTCols))
         exitCode = call(commandArgs)
         if exitCode != 0:
             print(commandArgs)

--- a/accelerometer/device.py
+++ b/accelerometer/device.py
@@ -20,7 +20,7 @@ def processInputFileToEpoch(inputFile, epochFile, stationaryFile, summary,
     useAbs=False, activityClassification=True,
     rawOutput=False, rawFile=None, npyOutput=False, npyFile=None,
     fftOutput=False, startTime=None, endTime=None,
-    verbose=False):
+    verbose=False, timeZoneOffset = 0):
     """Process raw accelerometer file, writing summary epoch stats to file
 
     This is usually achieved by
@@ -64,6 +64,7 @@ def processInputFileToEpoch(inputFile, epochFile, stationaryFile, summary,
     :param datetime startTime: Remove data before this time in analysis
     :param datetime endTime: Remove data after this time in analysis
     :param bool verbose: Print verbose output
+    :param int timeZoneOffset: timezone difference between configure and deployment
 
     :return: Raw processing summary values written to dict <summary>
     :rtype: void
@@ -158,6 +159,8 @@ def processInputFileToEpoch(inputFile, epochFile, stationaryFile, summary,
             commandArgs.append("startTime:" + startTime.strftime("%Y-%m-%dT%H:%M"))
         if endTime:
             commandArgs.append("endTime:" + endTime.strftime("%Y-%m-%dT%H:%M"))
+        if timeZoneOffset:
+            commandArgs.append("timeZoneOffset:" + str(timeZoneOffset))
         exitCode = call(commandArgs)
         if exitCode != 0:
             print(commandArgs)


### PR DESCRIPTION
Hi Aiden @aidendoherty,

Thanks for creating such an excellent package for the community. This package has been greatly helpful for my projects.

I have created an additional argument --timeZoneOffset (only for cwa cwa.gz files for now), to address this issue https://github.com/activityMonitoring/biobankAccelerometerAnalysis/issues/16, where device configuration and device deployment are conducted in different timezone.

for instance, if the device is configured in US eastern time zone, and deployed in US pacific time zone, "python3 accProcess.py data/sample.cwa.gz --timeZoneOffset -180" would do the job. "-180" refers to when the device deployment local time is 3 hours (180 minutes) behind the configure local time.

The second commit I submitted was simply to surface the csv arguments from java script to python script.

Please let me know if you need more information from me. I'm looking forward to incorporating these features to benefit more users, as well looking forward to developing more features/enhancements for this excellent package.

Best,
Xiangnan (dang_xiangnan@lilly.com)
