### PR TITLE
fix minor issue in accUtils.loadTimeSeriesCSV for --timeSeriesDataCol…

### DIFF
--- a/accelerometer/accUtils.py
+++ b/accelerometer/accUtils.py
@@ -175,6 +175,8 @@ def loadTimeSeriesCSV(tsFile):
     if header.columns[0] != TIME_SERIES_COL:
         tsData.index = pd.date_range(start=startDate, end=endDate,
             freq=str(sampleRate) + 's')
+    else:
+        tsData = tsData.set_index(pd.to_datetime(tsData[TIME_SERIES_COL]))
     return tsData
 
 


### PR DESCRIPTION
…umn True

Hi Aiden @aidendoherty,

there's a minor issue in the package: if --timeSeriesDateColumn True, accPlot.py will raise error due to the timestamp column (in the timeseries.csv file) was not converted to datetime type and set as index in accUtils.loadTimeSeriesCSV function.

I'm submitting this pull request to fix this issue by adding these two lines in accUtils.loadTimeSeriesCSV:
else:
        tsData = tsData.set_index(pd.to_datetime(tsData[TIME_SERIES_COL]))

Best,
Xiangnan