### PR TITLE
Gt3v2 support round 1

### DIFF
--- a/java/AxivityAx3Epochs.java
+++ b/java/AxivityAx3Epochs.java
@@ -655,13 +655,14 @@ public class AxivityAx3Epochs {
 	/**
 	 * check checksum with payload and header info
 	 */
-	private static void checkChecksum(int i,
-									  int separator,
-									  int type,
-									  int size,
-									  int date,
-									  int checkSum,
-									  int target_value) {
+	private static void checkChecksum(
+			int i,
+			int separator,
+			int type,
+			int size,
+			int date,
+			int checkSum,
+			int target_value) {
 		checkSum ^= (byte)separator;
 		checkSum ^= (byte)type;
 		checkSum ^= (byte)(size & 0xFF);

--- a/java/AxivityAx3Epochs.java
+++ b/java/AxivityAx3Epochs.java
@@ -165,7 +165,6 @@ public class AxivityAx3Epochs {
 				} else if (funcName.equals("timeZoneOffset")) {
 					timeZoneOffset = Integer.parseInt(funcParam);
 				} else if (funcName.equals("verbose")) {
-					logger.setLevel(Level.ALL);
 					verbose = Boolean.parseBoolean(funcParam.toLowerCase());
 				} else if (funcName.equals("epochPeriod")) {
 					epochPeriod = Integer.parseInt(funcParam);

--- a/java/AxivityAx3Epochs.java
+++ b/java/AxivityAx3Epochs.java
@@ -657,7 +657,7 @@ public class AxivityAx3Epochs {
 	 */
 	private static void checkChecksum(int i,
 									  int separator,
-			                          int type,
+									  int type,
 									  int size,
 									  int date,
 									  int checkSum,
@@ -794,19 +794,6 @@ public class AxivityAx3Epochs {
 				totalBytes++;
 				i++;
 
-//
-//				if (size == currentPayloadRead) {
-//					if (checkSum == header[i]) {
-//						System.out.println("Packet verified.");
-//					} else {
-//						System.out.println("Packet verfication failed.");
-//					}
-//				} else {
-//					checkSum ^= (byte) (header[i] & 0xFF);
-//				}
-
-
-				// verify check sum
 //
 //
 //				if (false && totalBytes%10000==0)

--- a/java/AxivityAx3Epochs.java
+++ b/java/AxivityAx3Epochs.java
@@ -474,7 +474,7 @@ public class AxivityAx3Epochs {
 	 * Reads a .gt3x file
 	 * For v1, the .zip archive should contain least 3 files.
 	 * For v2, the .zip arhive should contain only 2 files.
-	 * This method first verifies it is a valid v1/v2 file
+	 * This method first verifies if it is a valid v1/v2 file,
  	 * it will then parse the header and begin processing the activity.bin file for v1
 	 * and log.bin file for v2.
 	 */
@@ -548,7 +548,7 @@ public class AxivityAx3Epochs {
 					sampleFreq,
 					accelerationScale,
 					firstSampleTime);
-			if (gt3Version == VALID_GT3_V2_FILE)  readG3TXV2Epoch(
+			if (gt3Version == VALID_GT3_V2_FILE) readG3TXV2Epoch(
 					activityReader,
 					sampleDelta,
 					sampleFreq,
@@ -697,7 +697,7 @@ public class AxivityAx3Epochs {
 	}
 
 	/**
-	 ** Method to read all the x/y/z data from a GT3X (V1) activity.bin file.
+	 ** Method to read all the x/y/z data from a GT3X (V2) activity.bin file.
 	 ** File specification at: https://github.com/actigraph/NHANES-GT3X-File-Format/blob/master/fileformats/activity.bin.md
 	 ** Data is stored sequentially at the sample rate specified in the header (1/f = sampleDelta in milliseconds)
 	 ** Each pair of readings occupies an awkward 9 bytes to conserve space, so must be read 2 at a time.
@@ -731,8 +731,9 @@ public class AxivityAx3Epochs {
 		double[] twoSamples = null;
 		boolean isHeader = true;
 
-		// TODO: 1. process header for each record type. Try to standarlise this.
-		// 2. Look through all the relavent records.
+		// 1. process header
+		// 2. process payload based on type for each packet
+		// 3. validate checksum for each packet
 		try {
 			while ((datum=activityReader.read())!=-1){
 				// 1. Process header
@@ -776,7 +777,8 @@ public class AxivityAx3Epochs {
 					}
 
 				} else if (isPayload(i, size, initIndex)) {
-					//process payload depending on the type of record
+					// process payload depending on the type of record
+					// TODO: implement payload processing based on TYPE
 					// https://github.com/actigraph/GT3X-File-Format
 					checkSum ^= (byte)current;
 				} else {
@@ -793,33 +795,6 @@ public class AxivityAx3Epochs {
 
 				totalBytes++;
 				i++;
-
-//
-//
-//				if (false && totalBytes%10000==0)
-//					System.out.println("Converting sample.... "+(totalBytes/1000)+"K");
-//
-//				// if we have enough bytes to read two 36 bit data samples
-//				if (++i==9){
-//					twoSamples = readAccelPair(bytes, accelerationScale);
-//					twoSampleCounter = 2;
-//				}
-//
-//				// read the two samples from the sample counter
-//				while (twoSampleCounter>0) {
-//					twoSampleCounter--;
-//					i=0;
-//
-//					long time = Math.round((1000d*samples)/sampleFreq) + firstSampleTime;
-//					double x = twoSamples[3-twoSampleCounter*3];
-//					double y = twoSamples[4-twoSampleCounter*3];
-//					double z = twoSamples[5-twoSampleCounter*3];
-//					double temp = 1.0d; // don't know temp yet
-//					epochWriter.newValues(time, x, y, z, temp, errCounter);
-//
-//					samples += 1;
-//
-//				}
 			}
 		}
 		catch (IOException ex) {

--- a/java/AxivityAx3Epochs.java
+++ b/java/AxivityAx3Epochs.java
@@ -810,7 +810,7 @@ public class AxivityAx3Epochs {
 
 					double temp = 1.0d; // don't know temp yet
 					samples += 1;
-					long myTime = Math.round((1000d*samples)/sampleFreq) + firstSampleTime;
+					long myTime = Math.round((1000d*samples)/sampleFreq) + firstSampleTime*1000; // in Miliseconds
 					epochWriter.newValues(myTime, sample[1], sample[0], sample[2], temp, errCounter);
 				}
 			}

--- a/java/AxivityAx3Epochs.java
+++ b/java/AxivityAx3Epochs.java
@@ -783,30 +783,30 @@ public class AxivityAx3Epochs {
 						i++;
 
 						shifter |= ((current & 0xF0) >>> 4);
-						offset += 4;
+						offset += 12;
 					} else {
 						shifter = ((current & 0x0F) << 8);
-						offset += 4;
 
 						current = (byte) activityReader.read();
 						checkSum ^= (byte) current;
 						i++;
 						shifter |= (current & 0xFF);
-						offset += 8;
+						offset += 12;
 					}
 					if (shifter > 2047)
 						shifter += 61440;
+
 					axis_val = (short) shifter;
 					sample[axis] = axis_val / accelerationScale;
 					sample[axis] = (double) Math.round(sample[axis] * 1000d) / 1000d; // round to 3rd decimal
-					logger.log(Level.FINER, "i: " + i);
-					logger.log(Level.FINER, "x y z: " + sample[0] + " " + sample[1] + " " + sample[2]);
-
-					double temp = 1.0d; // don't know temp yet
-					samples += 1;
-					long myTime = Math.round((1000d*samples)/sampleFreq) + firstSampleTime*1000; // in Miliseconds
-					epochWriter.newValues(myTime, sample[1], sample[0], sample[2], temp, errCounter);
 				}
+				logger.log(Level.FINER, "i: " + i);
+				logger.log(Level.FINER, "x y z: " + sample[1] + " " + sample[0] + " " + sample[2]);
+
+				double temp = 1.0d; // don't know temp yet
+				samples += 1;
+				long myTime = Math.round((1000d*samples)/sampleFreq) + firstSampleTime*1000; // in Miliseconds
+				epochWriter.newValues(myTime, sample[1], sample[0], sample[2], temp, errCounter);
 			}
 		} catch (IOException ex) {
 			ex.printStackTrace(System.err);

--- a/java/logging.properties
+++ b/java/logging.properties
@@ -1,5 +1,5 @@
 handlers= java.util.logging.FileHandler
-.level= INFO
+.level= OFF
 java.util.logging.ConsoleHandler.level = INFO
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 com.logicbig.level = ALL

--- a/java/logging.properties
+++ b/java/logging.properties
@@ -1,0 +1,7 @@
+handlers= java.util.logging.FileHandler
+.level= INFO
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+com.logicbig.level = ALL
+java.util.logging.FileHandler.pattern=axivity.log
+java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter


### PR DESCRIPTION
Added incomplete support for GT3V2

1. Detection of v1 and v2 for `.gt3` format.
2. V2 packet header parsing.
3. Checksum validation for each packet.
4. Several minor code beautifications. 

To test this, run `AxivityAx3Epoches` on any valid gt3 v2 file.