### PR TITLE
Major fixes and improvements in the Java feature extraction code

### DIFF
--- a/java/EpochWriter.java
+++ b/java/EpochWriter.java
@@ -782,10 +782,12 @@ public class EpochWriter {
 		return line;
 	}
 
-	/* From table in paper:
+	/**
+     * From paper:
 	 * A universal, accurate intensity-based classification of different physical
 	 * activities using raw data of accelerometer.
 	 * Henri Vaha-Ypya, Tommi Vasankari, Pauliina Husu, Jaana Suni and Harri Sievanen
+     * https://www.ncbi.nlm.nih.gov/pubmed/24393233
 	 */
 	private String calculateMADFeatures(
 			double[] paVals) {
@@ -805,8 +807,8 @@ public class EpochWriter {
 			double diff = paVals[c] - vmMean;
 			MAD += Math.abs(diff);
 			MPD += Math.pow(Math.abs(diff), 1.5);
-			skew += Math.pow(diff/vmStd, 3);
-			kurt += Math.pow(diff/vmStd, 4);
+			skew += Math.pow(diff/(vmStd + 1E-8), 3);
+			kurt += Math.pow(diff/(vmStd + 1E-8), 4);
 		}
 
 		MAD /= N;


### PR DESCRIPTION
This PR contains a set of commits that deliver major fixes as well as improvements to the current Java feature extraction code. All changes are in `EpochWriter.java`. The affected functions are:

## `getFFTMagnitude`

Fix a mistake in the parsing of the FFT coefs to obtain the magnitudes. Add a new function `getFFTpower` which computes the spectral powers instead of the magnitudes, then `getFFTMagnitude` extends from it. Finally, normalize the FFT magnitudes/power by default.

## `sanDiegoFFT`

- Removal of 0Hz frequency before computing dominant frequencies: The signal is subtracted by the mean before computing the FFT coefs to find the dominant frequencies. Otherwise, the dominant frequency (`p1`, `f1`) will always be 0Hz, making these features uninformative.

- Fix spectral entropy: The calculation of the spectral entropy seemed slightly wrong, using the magnitudes instead of the powers. There was also some strange normalization applied (`magDC = vmFFT[0] / max`). This is now fixed to correctly use the powers, and normalization is also done correctly.

- Fix `p1`, `p33` (dominant powers): Change these to powers instead of magnitudes to be consistent with the papers. A strange normalization (dividing by max of the FFT coefs) is replaced to using logscale to handle the large values that `p1`, `p33` tend to have.

- Fix magnitude estimations (`FFT0`-`FFT14`): Magnitudes for 0Hz-14Hz (note: this is different from paper's 1Hz-15Hz) were computed using Welch's method, but the implementation had some mistakes. First, the running window did not reach until the end of the signal but only until half of it. Second, Welch's method uses overlapping windows. Another change in the estimation is to use logscale instead of the strange normalization.

## `unileverFeatures`

- Remove 0Hz frequency by subtracting the mean signal before FFT. This is to improve the  estimated dominant frequencies since 0Hz will always dominate otherwise.

- Use power instead of magnitude to be consistent with the paper implementation. Also use logscale for convenience to handle the large values that they tend to have.

- Increase the precision of the returned values since 3 decimals seems too little.

- Remove the optional computation of additional FFT coefficients as this seems to be never used.

## `calculateMADFeatures`
Fix a possible division-by-zero error when dividing by the standard deviation.

# Breaking changes
Since this PR modifies the extracted features, the current machine learning model (the one from `bash utilities/downloadDataModels.sh`) needs to be updated accordingly. That is, it needs to be retrained with the modified features and re-uploaded. Current users should somehow be notified to re-download the new model if they were to use the new code. If the users update the feature extraction but use the same old machine learning model, they will likely see a degradation of results.

