### PR TITLE
Gt3v2 fix get device id method

### DIFF
--- a/accelerometer/device.py
+++ b/accelerometer/device.py
@@ -533,12 +533,12 @@ def getGT3XDeviceId(cwaFile):
 
             if 'info.txt' in map(lambda x: x.filename, contents):
                 print('info.txt found..')
-                info_file = z.open('info.txt','r')
+                info_file = z.open('info.txt', 'r')
                 # print info_file.read()
                 for line in info_file:
-                    print(line.startswith("Serial Number:"), line)
-                    if line.startswith("Serial Number:"):
-                        return line.split("Serial Number:")
+                    if line.startswith(b"Serial Number:"):
+                        newline = line.decode("utf-8")
+                        return newline.split("Serial Number: ")[1]
             else:
                 print("Could not find info.txt file")
 

--- a/accelerometer/device.py
+++ b/accelerometer/device.py
@@ -538,7 +538,9 @@ def getGT3XDeviceId(cwaFile):
                 for line in info_file:
                     if line.startswith(b"Serial Number:"):
                         newline = line.decode("utf-8")
-                        return newline.split("Serial Number: ")[1]
+                        newline = newline.split("Serial Number: ")[1]
+                        print("Serial Number: "+newline)
+                        return newline
             else:
                 print("Could not find info.txt file")
 


### PR DESCRIPTION
The get device id seems to be broken as `startswith` expects type `byte` instead of type `string`.  This pull request fixes the issue. 