### PR TITLE
fix lowpass cutoff to be capped by Nyquist freq

### DIFF
--- a/java/LowpassFilter.java
+++ b/java/LowpassFilter.java
@@ -115,8 +115,22 @@ public class LowpassFilter {
 	// Constructs 4th order Butterworth lowpass filter with cutoff Fc at rate Fs.
 	public LowpassFilter(double Fc, double Fs)
 	{
+
+        /* 
+         * TODO: should it support edge case Fc == Fs/2? Current implementation
+         * makes all B coefficients zero in this case
+         */
+        if (Fc >= (Fs / 2)) {
+            System.out.format(
+                "\nThe specified lowpass filter cutoff (%s) "
+                + "is >= Nyquist frequency of the sampling rate (%s), "
+                + "therefore the cutoff will be capped at %s\n\n", Fc, Fs, Fs/2
+            );
+            Fc = (Fs / 2) * 0.999d;
+        }
+
 		// Calculate normalised cut-off
-		double W = Fc / (Fs / 2);
+        double W = Math.min( (Fc / (Fs / 2)), 0.999d);  // W cannot be > 1
 
 		// Create coefficients
 		B = new double[BUTTERWORTH4_NUM_COEFFICIENTS];


### PR DESCRIPTION
When `Fc >= Fs/2` in `LowpassFilter` of `LowpassFilter.java`, i.e. the cutoff frequency is >= the Nyquist frequency, the filtering fails, resulting in NaNs and Infs. This PR fixes that by capping the cutoff to less than the Nyquist freq, and prints a message to notify this.