### PR TITLE
fix sampleRate not passed for calibration

### DIFF
--- a/accelerometer/device.py
+++ b/accelerometer/device.py
@@ -102,7 +102,8 @@ def processInputFileToEpoch(inputFile, epochFile, stationaryFile, summary,
                 "outputFile:" + stationaryFile,
                 "verbose:" + str(verbose), "filter:true",
                 "getStationaryBouts:true", "epochPeriod:10",
-                "stationaryStd:" + str(staticStdG)]
+                "stationaryStd:" + str(staticStdG),
+                "sampleRate:" + str(sampleRate)]
             if javaHeapSpace:
                 commandArgs.insert(1, javaHeapSpace)
             if timeZoneOffset:


### PR DESCRIPTION
This is to fix a bug where `sampleRate` was not being passed to Java process when calibrating.