### PR TITLE
handle low sample rates in sanDiegoFFT

### DIFF
--- a/java/EpochWriter.java
+++ b/java/EpochWriter.java
@@ -702,8 +702,8 @@ public class EpochWriter {
 
 	private String sanDiegoFFT(double[] v) {
 
-		final int n = v.length;
         final double vMean = mean(v);
+		int n = v.length;
 		// Initialize array to compute FFT coefs
         double[] vFFT = new double[n];
         for (int i = 0; i < n; i++)  vFFT[i] = v[i] - vMean;  // note: we remove the 0Hz freq
@@ -753,6 +753,13 @@ public class EpochWriter {
         Note: Using the average magnitudes (instead of powers) yielded
         slightly better classification results in random forest
         */
+        // Resample to at least 30Hz to be able to compute FFT 0-14
+        final int MIN_SAMPLE_RATE = 30;
+        if (intendedSampleRate < MIN_SAMPLE_RATE) {
+            n = n / intendedSampleRate * MIN_SAMPLE_RATE;  // resampled length
+            intendedSampleRate = MIN_SAMPLE_RATE;  // new sample rate
+            v = Resample.resample(v, n);
+        }
 		final int numBins = 15;
 		double[] binnedFFT = new double[numBins];
         for (int i = 0; i < numBins; i++) binnedFFT[i] = 0;
@@ -896,7 +903,7 @@ public class EpochWriter {
 		return getFFTpower(FFT, true);
     }
 
-    /** 
+    /**
      * Get powers from FFT coefficients
 
      * The layout of FFT is as follows (computed using JTransforms, see

--- a/java/Resample.java
+++ b/java/Resample.java
@@ -1,5 +1,6 @@
 import java.util.Collections;
 import java.util.List;
+import java.util.Arrays;
 
 public class Resample{
 
@@ -49,7 +50,7 @@ public class Resample{
             yIntercept[i] = y.get(i) - time.get(i) * ySlope[i];
             zIntercept[i] = z.get(i) - time.get(i) * zSlope[i];
         }
-        
+
         // Perform the interpolation here
         for (int i = 0; i < timeI.length; i++) {
             if (timeI[i] > time.get(time.size() - 1)) {
@@ -75,6 +76,60 @@ public class Resample{
                 }
             }
         }
+    }
+
+    /**
+    * Stripped down version of interpLinear for 1D array
+    */
+    public static final double[] resample(double[] x, int n)
+    {
+        final int m = x.length;
+        if (m == n) return x;
+
+        double[] t = new double[m];
+        double[] tNew = new double[n];
+        double[] xNew = new double[n];
+
+        for (int i=0; i<m; i++) t[i] = i;
+        for (int i=0; i<n; i++) tNew[i] = (double) i * m / n;
+
+        double dt;
+        double dx;
+        double[] xSlope = new double[m-1];
+        double[] xIntercept = new double[m-1];
+
+        // Calculate the line equation (i.e. slope and intercept) between each point
+        for (int i=(m-2); i >= 0; i--) {
+            dt = t[i+1] - t[i];
+            if (dt <= 0){
+                t[i] = t[i+1] - 1;
+                dt = 1;
+            }
+            dx = x[i+1] - x[i];
+            xSlope[i] = dx / dt;
+            xIntercept[i] = x[i] - t[i] * xSlope[i];
+        }
+
+        // Perform the interpolation here
+        for (int i = 0; i < n; i++) {
+            if (tNew[i] > t[m-1]) {
+                xNew[i] = x[m-1];
+            } else if (tNew[i] < t[0]) {
+                xNew[i] = x[0];
+            } else {
+                int loc = Arrays.binarySearch(t, tNew[i]);
+                if (loc < -1) {
+                    loc = -loc - 2;
+                    xNew[i] = xSlope[loc] * tNew[i] + xIntercept[loc];
+                }
+                else {
+                    xNew[i] = x[loc];
+                }
+            }
+        }
+
+        return xNew;
+
     }
 
 }


### PR DESCRIPTION
This is to fix an issue when passing `sampleRate` less than 30, in which case we cannot compute FFT0-FFT14 in `sanDiegoFFT`. To handle this, just resample the signal to 30Hz right before computing.