### PR TITLE
fix FFT and entropy normalization

### DIFF
--- a/java/EpochWriter.java
+++ b/java/EpochWriter.java
@@ -723,7 +723,7 @@ public class EpochWriter {
             if (p <= 0) continue;  // skip to next loop if power is non-positive
             H += -p * Math.log(p + 1E-8);
         }
-        H /= Math.log(vFFTpow.length);  // Normalize spectral entropy
+        H /= Math.log(n);  // Normalize spectral entropy
 
         /*
         Find dominant frequencies overall, also between 0.3Hz and 3Hz
@@ -896,7 +896,7 @@ public class EpochWriter {
 		return getFFTpower(FFT, true);
     }
 
-    /** 
+    /**
      * Get powers from FFT coefficients
 
      * The layout of FFT is as follows (computed using JTransforms, see
@@ -942,7 +942,7 @@ public class EpochWriter {
 
         if (normalize) {
             // Divide by length of the signal
-            for (int i=0; i<m; i++) FFTpow[i] /= n;
+            for (int i=0; i<m; i++) FFTpow[i] /= n*n;
         }
 
         return FFTpow;


### PR DESCRIPTION
To normalize in `getFFTpower` we need to divide by n^2 instead of n, as it is the FFT coefs that get divided by n, then squared. This wouldn't be an issue except when working with data with _varying sampling rate_, in which case the features wouldn't be comparable.

The spectral entropy normalization is also fixed to use the whole signal length.

# Breaking changes
This PR affects the extracted features, so it will be necessary to update the machine learning model if this PR is to be applied. Suggestion: Perhaps we can hard-code the download of the model if not present in the default path?