### PR TITLE
auto download builtin ML models if not found

### DIFF
--- a/accPlot.py
+++ b/accPlot.py
@@ -37,9 +37,8 @@ def main():
                             help="input .csv.gz time series file to plot")
     parser.add_argument('plotFile', metavar='output file', type=str,
                             help="output .png file to plot to")
-    parser.add_argument('--activityModel', type=str,
-                            default="activityModels/doherty2018-apr20Update.tar",
-                            help="""trained activity model .tar file""")
+    parser.add_argument('--activityModel', type=str, default="doherty2018",
+                            help="""activity classification model""")
 
     # check input is ok
     if len(sys.argv) < 3:
@@ -56,8 +55,7 @@ def main():
 
 
 
-def plotTimeSeries(tsFile, plotFile,
-    activityModel="activityModels/doherty2018-apr20Update.tar"):
+def plotTimeSeries(tsFile, plotFile, activityModel="doherty2018"):
     """Plot overall activity and classified activity types
 
     :param str tsFile: Input filename with .csv.gz time series data
@@ -86,9 +84,9 @@ def plotTimeSeries(tsFile, plotFile,
         if col not in [accUtils.TIME_SERIES_COL, 'imputed', 'acc', 'MET']:
             labels += [col]
     print(labels)
-    if 'doherty2018' in activityModel:
+    if activityModel == 'doherty2018':
         labels_as_col = DOHERTY_NatComms_COLOURS
-    elif 'willetts2018' in activityModel:
+    elif activityModel == 'willetts2018':
         labels_as_col = WILLETS_SciReports_COLOURS
     # add imputation label colour
     labels_as_col['imputed'] = '#fafc6f'

--- a/accProcess.py
+++ b/accProcess.py
@@ -33,7 +33,7 @@ def main():
     #optional inputs
     parser.add_argument('--timeZoneOffset',
                             metavar='e.g. -180', default=0,
-                            type=int, help="""timezone minutes offset induced 
+                            type=int, help="""timezone minutes offset induced
                             by timezone difference from configure timezone and
                             deployment timezone
                             (default : %(default)s""")
@@ -76,26 +76,26 @@ def main():
                              (default : %(default)s)""")
     parser.add_argument('--csvStartTime',
                             metavar='e.g. 1991-01-01T23:59', default=None,
-                            type=str2date, help="""start time for csv file 
+                            type=str2date, help="""start time for csv file
                             when time column is not available
                             (default : %(default)s)""")
     parser.add_argument('--csvSampleRate',
                             metavar='Hz, or samples/second', default=None,
-                            type=float, help="""sample rate for csv file 
+                            type=float, help="""sample rate for csv file
                             when time column is not available (default
                              : %(default)s)""")
     parser.add_argument('--csvTimeFormat',
                             metavar='time format', default=None,
-                            type=str, help="""time format for csv file 
+                            type=str, help="""time format for csv file
                             when time column is available (default
-                             : %(default)s)""")                         
+                             : %(default)s)""")
     parser.add_argument('--csvStartRow',
                             metavar='start row', default=None, type=int,
                             help="""start row for accelerometer data in csv file (default
-                             : %(default)s, must be an integer)""")                         
+                             : %(default)s, must be an integer)""")
     parser.add_argument('--csvXYZTCols',
                             metavar='XYZT Cols', default=None,
-                            type=str, help="""index of column positions for XYZT columns, 
+                            type=str, help="""index of column positions for XYZT columns,
                             e.g. "0,1,2,3" (default
                              : %(default)s)""")
     # calibration parameters
@@ -156,8 +156,13 @@ def main():
                             activity type
                             (default : %(default)s)""")
     parser.add_argument('--activityModel', type=str,
-                            default="activityModels/doherty2018-apr20Update.tar",
-                            help="""trained activity model .tar file""")
+                            default="doherty2018", help="""activity
+                            classification model to use, either 'doherty2018'
+                            or 'willetts2018' (default : %(default)s)""")
+    parser.add_argument('--activityModelPath', type=str,
+                            default=None, help="""User-specified path to
+                            activity classification model. If specified, it
+                            ignores --activityModel. (default : %(default)s)""")
     parser.add_argument('--rawOutput',
                             metavar='True/False', default=False, type=str2bool,
                             help="""output calibrated and resampled raw data to
@@ -205,7 +210,7 @@ def main():
                              (default : %(default)s)""")
     parser.add_argument('--psd',
                             metavar='True/False', default=False, type=str2bool,
-                            help="""Calculate power spectral density for 24 hour 
+                            help="""Calculate power spectral density for 24 hour
                                     circadian period
                              (default : %(default)s)""")
     parser.add_argument('--fourierFrequency',
@@ -214,12 +219,12 @@ def main():
                              (default : %(default)s)""")
     parser.add_argument('--fourierWithAcc',
                             metavar='True/False', default=False, type=str2bool,
-                            help="""True will do the Fourier analysis of circadian rhythms (for PSD and Fourier Frequency) with 
+                            help="""True will do the Fourier analysis of circadian rhythms (for PSD and Fourier Frequency) with
                                     acceleration data instead of sleep signal
-                             (default : %(default)s)""") 
+                             (default : %(default)s)""")
     parser.add_argument('--m10l5',
                             metavar='True/False', default=False, type=str2bool,
-                            help="""Calculate relative amplitude of most and 
+                            help="""Calculate relative amplitude of most and
                                     least active acceleration periods for circadian rhythm analysis
                              (default : %(default)s)""")
 
@@ -327,7 +332,7 @@ def main():
             rawOutput=args.rawOutput, rawFile=args.rawFile,
             npyOutput=args.npyOutput, npyFile=args.npyFile,
             fftOutput=args.fftOutput, startTime=args.startTime,
-            endTime=args.endTime, verbose=args.verbose, 
+            endTime=args.endTime, verbose=args.verbose,
             timeZoneOffset=args.timeZoneOffset,
             csvStartTime=args.csvStartTime, csvSampleRate=args.csvSampleRate,
             csvTimeFormat=args.csvTimeFormat, csvStartRow=args.csvStartRow,
@@ -341,9 +346,9 @@ def main():
         activityClassification=args.activityClassification, startTime=args.startTime,
         endTime=args.endTime, epochPeriod=args.epochPeriod,
         stationaryStd=args.stationaryStd, mgMVPA=args.mgMVPA,
-        mgVPA=args.mgVPA, activityModel=args.activityModel,
-        intensityDistribution=args.intensityDistribution, psd=args.psd, 
-        fourierFrequency=args.fourierFrequency, fourierWithAcc=args.fourierWithAcc, m10l5=args.m10l5, 
+        mgVPA=args.mgVPA, activityModel=args.activityModel, activityModelPath=args.activityModelPath,
+        intensityDistribution=args.intensityDistribution, psd=args.psd,
+        fourierFrequency=args.fourierFrequency, fourierWithAcc=args.fourierWithAcc, m10l5=args.m10l5,
         verbose=args.verbose)
 
     # Generate time series file (note: this will also resample to epochData so do this last)

--- a/accelerometer/summariseEpoch.py
+++ b/accelerometer/summariseEpoch.py
@@ -15,8 +15,8 @@ from datetime import timedelta
 def getActivitySummary(epochFile, nonWearFile, summary,
     activityClassification=True, startTime=None, endTime=None,
     epochPeriod=30, stationaryStd=13, minNonWearDuration=60, mgMVPA=100,
-    mgVPA=425, activityModel="activityModels/doherty2018-apr20Update.tar",
-    intensityDistribution=False, psd=False, fourierFrequency=False, fourierWithAcc=False, m10l5=False, 
+    mgVPA=425, activityModel="doherty2018", activityModelPath=None,
+    intensityDistribution=False, psd=False, fourierFrequency=False, fourierWithAcc=False, m10l5=False,
     verbose=False):
     """Calculate overall activity summary from <epochFile> data
 
@@ -106,7 +106,7 @@ def getActivitySummary(epochFile, nonWearFile, summary,
 
     # Predict activity from features, and add label column
     if activityClassification:
-        e, labels = accClassification.activityClassification(e, activityModel)
+        e, labels = accClassification.activityClassification(e, activityModel, activityModelPath)
     else:
         labels = []
 
@@ -132,7 +132,7 @@ def getActivitySummary(epochFile, nonWearFile, summary,
         circadianRhythms.calculateFourierFreq(e, epochPeriod, fourierWithAcc, labels, summary)
     if m10l5:
         circadianRhythms.calculateM10L5(e, epochPeriod, summary)
- 
+
     # Main movement summaries
     writeMovementSummaries(e, labels, summary)
 
@@ -417,9 +417,9 @@ def calculateECDF(e, inputCol, summary):
     for x, ecdf in zip(ecdfXVals, accEcdf):
         summary[inputCol + '-ecdf-' + str(accUtils.formatNum(x,0)) + 'mg'] = \
             accUtils.formatNum(ecdf, 5)
-  
 
-    
+
+
 def writeMovementSummaries(e, labels, summary):
     """Write overall summary stats for each activity type to summary dict
 
@@ -471,5 +471,5 @@ def writeMovementSummaries(e, labels, summary):
             summary[accType + '-hourOfWeekend-' + str(i) + '-avg'] = hourOfWeekend
 
 
-    
-    
+
+


### PR DESCRIPTION
Download the builtin ML models (`doherty2018`, `willetts2018`) during runtime if the model files are not found. `--activityModel` flag is now to be interpreted as the builtin model type to use (either `doherty2018` or `willetts2018`) rather than the path to the model file. The code will then link to the corresponding file via the dictionary `MODELS` in `accClassification.py`.

This change makes it easier to update our builtin models in the future without having to notify the users to manually redownload the ML models, and also `--activityModel` wouldn't need to change to the updated path/filename. Instead, it will be on us to simply change `MODELS` in `accClassification.py` to the new filenames.

Users can still use a custom activity model by supplying the path in `--activityModelPath`. If supplied, then `--activityModel` is ignored.