### PR TITLE
hotfix to allow sampleRate of 25Hz

### DIFF
--- a/accProcess.py
+++ b/accProcess.py
@@ -11,6 +11,7 @@ import os
 import accelerometer.summariseEpoch
 import pandas as pd
 import atexit
+import warnings
 
 
 def main():
@@ -225,6 +226,13 @@ def main():
 
 
     args = parser.parse_args()
+
+    assert args.sampleRate >= 25, "sampleRate<25 currently not supported"
+
+    if args.sampleRate <= 40:
+        warnings.warn("Skipping lowpass filter (--useFilter False) as sampleRate too low (<= 40)")
+        args.useFilter = False
+
 
     processingStartTime = datetime.datetime.now()
 

--- a/java/AccelerometerParser.java
+++ b/java/AccelerometerParser.java
@@ -66,7 +66,7 @@ public class AccelerometerParser {
     	long endTime = -1;
     	int timeZoneOffset = 0;
     	boolean getFeatures = false;
-    	int numFFTbins = 15; // number of fft bins to print
+    	int numFFTbins = 12; // number of fft bins to print
 
     	// Must supply additional information when loading from a .csv file
     	LocalDateTime csvStartTime = null; // start date of first sample


### PR DESCRIPTION
Number of FFT bins in `sanDiegoFFT` capped at 12 to be able to handle low `sampleRate` of 25Hz. It still doesnt support `sampleRate` strictly lower than 25Hz. An assertion was added to check that `args.sampleRate >=25`.

Also turn off the lowpass filter (with default cutoff of 20) when `args.sampleRate <= 40` since then Nyquist freq will be less than the cutoff.

# Breaking changes
A new ML model needs to be uploaded with this PR as the number of features (the `fft` ones) are now different.