### PR TITLE
propagate verbose argument to CsvReader.java

### DIFF
--- a/java/AccelerometerParser.java
+++ b/java/AccelerometerParser.java
@@ -236,7 +236,7 @@ public class AccelerometerParser {
 					System.exit(-1);
 				}
 				CsvReader.readCSVEpochs(accFile, epochWriter, csvStartTime,
-					csvSampleRate, csvTimeFormat, csvStartRow, csvXYZTCols);
+					csvSampleRate, csvTimeFormat, csvStartRow, csvXYZTCols, verbose);
 			} else {
 				System.err.println("Unrecognised file format for: " + accFile);
 				System.exit(-1);

--- a/java/CsvReader.java
+++ b/java/CsvReader.java
@@ -20,7 +20,8 @@ public class CsvReader extends DeviceReader {
             double csvSampleRate,
             DateTimeFormatter csvTimeFormat,
             int csvStartRow,
-            List<Integer> csvXYZTCols) {
+            List<Integer> csvXYZTCols,
+            Boolean verbose) {
 
         try {
             BufferedReader accStream =  new BufferedReader(new FileReader(accFile));
@@ -77,7 +78,9 @@ public class CsvReader extends DeviceReader {
                             time += 1000/csvSampleRate;
                         }
                 } else {
-                    System.err.println(".csv line " + lineNumber + " had too few columns :\n" + line);
+                    if (verbose) {
+                        System.err.println(".csv line " + lineNumber + " had too few columns :\n" + line);
+                    }
                 }
             }
 


### PR DESCRIPTION
this pull request is to allow verbose argument in CsvReader.java

In current setup, the csv parser will complain rows with fewer columns. This behavior is not always preferred. For instance, some of the csv files have explicit missing rows, meaning that for time periods with missing accelerometer data, there is still a time column with timestamp, but the other columns are empty:
"20200101 10:10:10.000,,,"

the csv parser will ignore this row (which is desired), but complain about it. Propagating the verbose parameter will allow disabling this by default. This helps to avoid large size of output files when there are huge number of missing rows in the csv files.

Best,
Xiangnan