### PR TITLE
allow daylight savings crossover check from different timezones

### DIFF
--- a/accPlot.py
+++ b/accPlot.py
@@ -44,10 +44,6 @@ def main():
                             metavar='True/False', default=True, type=str2bool,
                             help="""Highly recommended method to show imputed 
                             missing data (default : %(default)s)""")
-    parser.add_argument('--imputedLabels',
-                            metavar='True/False', default=False, type=str2bool,
-                            help="""If activity classification during imputed
-                            period will be displayed (default : %(default)s)""")
 
     # check input is ok
     if len(sys.argv) < 3:
@@ -61,8 +57,7 @@ def main():
     # and then call plot function
     plotTimeSeries(args.timeSeriesFile, args.plotFile,
         activityModel=args.activityModel,
-        useRecommendedImputation=args.useRecommendedImputation,
-        imputedLabels=args.imputedLabels)
+        useRecommendedImputation=args.useRecommendedImputation)
 
 
 
@@ -70,8 +65,7 @@ def plotTimeSeries(
         tsFile,
         plotFile,
         activityModel="activityModels/doherty2018-apr20Update.tar",
-        useRecommendedImputation=True,
-        imputedLabels=False):
+        useRecommendedImputation=True,):
     """Plot overall activity and classified activity types
 
     :param str tsFile: Input filename with .csv.gz time series data
@@ -79,8 +73,6 @@ def plotTimeSeries(
     :param str activityModel: Input tar model file used for activity classification
     :param bool useRecommendedImputation: Highly recommended method to show  
         imputed values for missing data
-    :param bool imputedLabels: If activity classification during imputed period 
-        will be displayed
 
     :return: Writes plot to <plotFile>
     :rtype: void
@@ -117,12 +109,6 @@ def plotTimeSeries(
     d['date'] = d.index.date
     if not useRecommendedImputation:
         d = d[d['imputed']==0] # if requested, do not show imputed values
-        
-    if imputedLabels:
-        labelsPosition = 0.75
-    else:
-        labelsPosition = 1
-    
     groupedDays = d[['acc','time','imputed'] + labels].groupby(by=d['date'])
     nrows = len(groupedDays) + 1
 
@@ -143,18 +129,13 @@ def plotTimeSeries(
         # and then plot time series data for this day
         plt.subplot(nrows, 1, i+1)
         plt.plot(timeSeries, group['acc'], c='k')
-        if imputedLabels:
-            plt.fill_between(timeSeries, y1 = np.multiply(group['imputed'], ymax), 
-                y2 = np.multiply(group['imputed'], ymax * labelsPosition),
-                color = labels_as_col['imputed'], alpha=1.0, where=group['imputed']==1)
-        else:
-            plt.fill(timeSeries, np.multiply(group['imputed'], ymax),
+        plt.fill(timeSeries, np.multiply(group['imputed'], ymax),
             labels_as_col['imputed'], alpha=1.0)
 
         # change display properties of this subplot
         ax = plt.gca()
         if len(labels)>0:
-            ax.stackplot(timeSeries, [np.multiply(group[l], ymax * labelsPosition) for l in labels],
+            ax.stackplot(timeSeries, [np.multiply(group[l], ymax) for l in labels],
                 colors=[labels_as_col[l] for l in labels], alpha=0.5, edgecolor="none")
         # add date label to left hand side of each day's activity plot
         plt.title(

--- a/accPlot.py
+++ b/accPlot.py
@@ -129,13 +129,14 @@ def plotTimeSeries(
         # and then plot time series data for this day
         plt.subplot(nrows, 1, i+1)
         plt.plot(timeSeries, group['acc'], c='k')
-        plt.fill(timeSeries, np.multiply(group['imputed'], ymax),
-            labels_as_col['imputed'], alpha=1.0)
+        plt.fill_between(timeSeries, y1 = np.multiply(group['imputed'], ymax), 
+            y2 = np.multiply(group['imputed'], ymax * 0.5),
+            color = labels_as_col['imputed'], alpha=1.0)
 
         # change display properties of this subplot
         ax = plt.gca()
         if len(labels)>0:
-            ax.stackplot(timeSeries, [np.multiply(group[l], ymax) for l in labels],
+            ax.stackplot(timeSeries, [np.multiply(group[l], ymax * 0.5) for l in labels],
                 colors=[labels_as_col[l] for l in labels], alpha=0.5, edgecolor="none")
         # add date label to left hand side of each day's activity plot
         plt.title(

--- a/accPlot.py
+++ b/accPlot.py
@@ -44,6 +44,10 @@ def main():
                             metavar='True/False', default=True, type=str2bool,
                             help="""Highly recommended method to show imputed 
                             missing data (default : %(default)s)""")
+    parser.add_argument('--imputedLabels',
+                            metavar='True/False', default=False, type=str2bool,
+                            help="""If activity classification during imputed
+                            period will be displayed (default : %(default)s)""")
 
     # check input is ok
     if len(sys.argv) < 3:
@@ -57,7 +61,8 @@ def main():
     # and then call plot function
     plotTimeSeries(args.timeSeriesFile, args.plotFile,
         activityModel=args.activityModel,
-        useRecommendedImputation=args.useRecommendedImputation)
+        useRecommendedImputation=args.useRecommendedImputation,
+        imputedLabels=args.imputedLabels)
 
 
 
@@ -65,7 +70,8 @@ def plotTimeSeries(
         tsFile,
         plotFile,
         activityModel="activityModels/doherty2018-apr20Update.tar",
-        useRecommendedImputation=True,):
+        useRecommendedImputation=True,
+        imputedLabels=False):
     """Plot overall activity and classified activity types
 
     :param str tsFile: Input filename with .csv.gz time series data
@@ -73,6 +79,8 @@ def plotTimeSeries(
     :param str activityModel: Input tar model file used for activity classification
     :param bool useRecommendedImputation: Highly recommended method to show  
         imputed values for missing data
+    :param bool imputedLabels: If activity classification during imputed period 
+        will be displayed
 
     :return: Writes plot to <plotFile>
     :rtype: void
@@ -109,6 +117,12 @@ def plotTimeSeries(
     d['date'] = d.index.date
     if not useRecommendedImputation:
         d = d[d['imputed']==0] # if requested, do not show imputed values
+        
+    if imputedLabels:
+        labelsPosition = 0.75
+    else:
+        labelsPosition = 1
+    
     groupedDays = d[['acc','time','imputed'] + labels].groupby(by=d['date'])
     nrows = len(groupedDays) + 1
 
@@ -129,14 +143,18 @@ def plotTimeSeries(
         # and then plot time series data for this day
         plt.subplot(nrows, 1, i+1)
         plt.plot(timeSeries, group['acc'], c='k')
-        plt.fill_between(timeSeries, y1 = np.multiply(group['imputed'], ymax), 
-            y2 = np.multiply(group['imputed'], ymax * 0.5),
-            color = labels_as_col['imputed'], alpha=1.0)
+        if imputedLabels:
+            plt.fill_between(timeSeries, y1 = np.multiply(group['imputed'], ymax), 
+                y2 = np.multiply(group['imputed'], ymax * labelsPosition),
+                color = labels_as_col['imputed'], alpha=1.0, where=group['imputed']==1)
+        else:
+            plt.fill(timeSeries, np.multiply(group['imputed'], ymax),
+            labels_as_col['imputed'], alpha=1.0)
 
         # change display properties of this subplot
         ax = plt.gca()
         if len(labels)>0:
-            ax.stackplot(timeSeries, [np.multiply(group[l], ymax * 0.5) for l in labels],
+            ax.stackplot(timeSeries, [np.multiply(group[l], ymax * labelsPosition) for l in labels],
                 colors=[labels_as_col[l] for l in labels], alpha=0.5, edgecolor="none")
         # add date label to left hand side of each day's activity plot
         plt.title(

--- a/accProcess.py
+++ b/accProcess.py
@@ -38,6 +38,11 @@ def main():
                             by timezone difference from configure timezone and
                             deployment timezone
                             (default : %(default)s""")
+    parser.add_argument('--timeZone',
+                            metavar='e.g. Europe/London', default='Europe/London',
+                            type=int, help="""timezone in country/city format to
+                            be used for daylight savings crossover check
+                            (default : %(default)s""")
     parser.add_argument('--startTime',
                             metavar='e.g. 1991-01-01T23:59', default=None,
                             type=str2date, help="""removes data before this
@@ -342,7 +347,8 @@ def main():
     # Summarise epoch
     epochData, labels = accelerometer.summariseEpoch.getActivitySummary(
         args.epochFile, args.nonWearFile, summary,
-        activityClassification=args.activityClassification, startTime=args.startTime,
+        activityClassification=args.activityClassification, 
+        timeZone=args.timeZone, startTime=args.startTime,
         endTime=args.endTime, epochPeriod=args.epochPeriod,
         stationaryStd=args.stationaryStd, mgMVPA=args.mgMVPA,
         mgVPA=args.mgVPA, activityModel=args.activityModel,

--- a/accelerometer/summariseEpoch.py
+++ b/accelerometer/summariseEpoch.py
@@ -13,7 +13,8 @@ from scipy import fftpack
 from datetime import timedelta
 
 def getActivitySummary(epochFile, nonWearFile, summary,
-    activityClassification=True, startTime=None, endTime=None,
+    activityClassification=True, timeZone='Europe/London', 
+    startTime=None, endTime=None,
     epochPeriod=30, stationaryStd=13, minNonWearDuration=60, 
     mgMVPA=100, mgVPA=425, 
     activityModel="activityModels/doherty-may20.tar",
@@ -35,6 +36,8 @@ def getActivitySummary(epochFile, nonWearFile, summary,
     :param str nonWearFile: Output filename for non wear .csv.gz episodes
     :param dict summary: Output dictionary containing all summary metrics
     :param bool activityClassification: Perform machine learning of activity states
+    :param str timeZone: timezone in country/city format to be used for daylight 
+        savings crossover check
     :param datetime startTime: Remove data before this time in analysis
     :param datetime endTime: Remove data after this time in analysis
     :param int epochPeriod: Size of epoch time window (in seconds)
@@ -102,7 +105,7 @@ def getActivitySummary(epochFile, nonWearFile, summary,
     e = get_interrupts(e, epochPeriod, summary)
 
     # Check if data occurs at a daylight savings crossover
-    e = check_daylight_savings_crossover(e, startTime, endTime, summary)
+    e = check_daylight_savings_crossover(e, timeZone, startTime, endTime, summary)
 
     # Calculate wear-time statistics, and write nonWear episodes to file
     get_wear_time_stats(e, epochPeriod, stationaryStd, minNonWearDuration,
@@ -177,7 +180,7 @@ def get_interrupts(e, epochPeriod, summary):
     return e
 
 
-def check_daylight_savings_crossover(e, startTime, endTime, summary):
+def check_daylight_savings_crossover(e, startTime, endTime, summary, timeZone='Europe/London'):
     """Check if data occurs at a daylight savings crossover
 
     If daylight savings crossover, update times after time-change by +/- 1hr.
@@ -187,6 +190,8 @@ def check_daylight_savings_crossover(e, startTime, endTime, summary):
     :param datetime startTime: Remove data before this time in analysis
     :param datetime endTime: Remove data after this time in analysis
     :param dict summary: Output dictionary containing all summary metrics
+    :param str timeZone: timezone in country/city format to be used for daylight 
+        savings crossover check
 
     :return: Write dict <summary> key 'quality-daylightSavingsCrossover'
     :rtype: void
@@ -196,7 +201,7 @@ def check_daylight_savings_crossover(e, startTime, endTime, summary):
     """
 
     daylightSavingsCrossover = 0
-    localTime = pytz.timezone('Europe/London')
+    localTime = pytz.timezone(timeZone)
     # Convert because pytz can error if not using python datetime type
     startTimeZone = localTime.localize(startTime.to_pydatetime())
     endTimeZone = localTime.localize(endTime.to_pydatetime())

--- a/accelerometer/summariseEpoch.py
+++ b/accelerometer/summariseEpoch.py
@@ -105,7 +105,7 @@ def getActivitySummary(epochFile, nonWearFile, summary,
     e = get_interrupts(e, epochPeriod, summary)
 
     # Check if data occurs at a daylight savings crossover
-    e = check_daylight_savings_crossover(e, timeZone, startTime, endTime, summary)
+    e = check_daylight_savings_crossover(e, startTime, endTime, summary, timeZone)
 
     # Calculate wear-time statistics, and write nonWear episodes to file
     get_wear_time_stats(e, epochPeriod, stationaryStd, minNonWearDuration,


### PR DESCRIPTION
This pull request is to allow daylight savings crossover check from different timezones.

Currently, in function of check_daylight_savings_crossover, it is hardcoded to check for timezone "Europe/London". This commit is to set up a new argument of "timeZone" to allow more flexibility.

The default of the "timeZone" has been set to "Europe/London" to allow compatibility. This argument has been exposed to accProcess.py 's parser, function of getActivitySummary, and function of check_daylight_savings_crossover.

(the commit history was a bit messed up as I started a new branch in the middle of another pull request, but the files changed are clean.)

Best,
Xiangnan