### PR TITLE
fix small bug: missing field in summary.json

### DIFF
--- a/accelerometer/summariseEpoch.py
+++ b/accelerometer/summariseEpoch.py
@@ -240,8 +240,8 @@ def check_daylight_savings_crossover(e, startTime, endTime, summary,
         # Reset startTime and endTime variables
         startTime = pd.to_datetime(e.index.values[0])
         endTime = pd.to_datetime(e.index.values[-1])
-        # And record to output summary
-        summary['quality-daylightSavingsCrossover'] = daylightSavingsCrossover
+    # And record to output summary
+    summary['quality-daylightSavingsCrossover'] = daylightSavingsCrossover
     return e
 
 


### PR DESCRIPTION
Smallest PR ever.

This is to fix a missing field in the summary.json output file `quality-daylightSavingsCrossover` which was only being set when there was a crossover.