### PR TITLE
make use of cutpoint based definitions explicit

### DIFF
--- a/accProcess.py
+++ b/accProcess.py
@@ -146,12 +146,12 @@ def main():
                             help="""calibration sphere threshold (default
                              : %(default)s mg))""")
     # activity parameters
-    parser.add_argument('--mgCutpointMVPA',
+    parser.add_argument('--mgCutPointMVPA',
                             metavar="mg", default=100, type=int,
-                            help="""MVPA threshold for cutpoint based activity definition (default : %(default)s)""")
-    parser.add_argument('--mgCutpointVPA',
+                            help="""MVPA threshold for CutPoint based activity definition (default : %(default)s)""")
+    parser.add_argument('--mgCutPointVPA',
                             metavar="mg", default=425, type=int,
-                            help="""VPA threshold for cutpoint based activity definition (default : %(default)s)""")
+                            help="""VPA threshold for CutPoint based activity definition (default : %(default)s)""")
     parser.add_argument('--intensityDistribution',
                             metavar='True/False', default=False, type=str2bool,
                             help="""Save intensity distribution
@@ -352,8 +352,8 @@ def main():
         activityClassification=args.activityClassification,
         timeZone=args.timeZone, startTime=args.startTime,
         endTime=args.endTime, epochPeriod=args.epochPeriod,
-        stationaryStd=args.stationaryStd, mgCutpointMVPA=args.mgCutpointMVPA,
-        mgCutpointVPA=args.mgCutpointVPA, activityModel=args.activityModel,
+        stationaryStd=args.stationaryStd, mgCutPointMVPA=args.mgCutPointMVPA,
+        mgCutPointVPA=args.mgCutPointVPA, activityModel=args.activityModel,
         intensityDistribution=args.intensityDistribution,
         useRecommendedImputation=args.useRecommendedImputation,
         psd=args.psd, fourierFrequency=args.fourierFrequency,

--- a/accProcess.py
+++ b/accProcess.py
@@ -146,12 +146,12 @@ def main():
                             help="""calibration sphere threshold (default
                              : %(default)s mg))""")
     # activity parameters
-    parser.add_argument('--mgMVPA',
+    parser.add_argument('--mgCutpointMVPA',
                             metavar="mg", default=100, type=int,
-                            help="""MVPA threshold (default : %(default)s)""")
-    parser.add_argument('--mgVPA',
+                            help="""MVPA threshold for cutpoint based activity definition (default : %(default)s)""")
+    parser.add_argument('--mgCutpointVPA',
                             metavar="mg", default=425, type=int,
-                            help="""VPA threshold (default : %(default)s)""")
+                            help="""VPA threshold for cutpoint based activity definition (default : %(default)s)""")
     parser.add_argument('--intensityDistribution',
                             metavar='True/False', default=False, type=str2bool,
                             help="""Save intensity distribution
@@ -352,8 +352,8 @@ def main():
         activityClassification=args.activityClassification,
         timeZone=args.timeZone, startTime=args.startTime,
         endTime=args.endTime, epochPeriod=args.epochPeriod,
-        stationaryStd=args.stationaryStd, mgMVPA=args.mgMVPA,
-        mgVPA=args.mgVPA, activityModel=args.activityModel,
+        stationaryStd=args.stationaryStd, mgCutpointMVPA=args.mgCutpointMVPA,
+        mgCutpointVPA=args.mgCutpointVPA, activityModel=args.activityModel,
         intensityDistribution=args.intensityDistribution,
         useRecommendedImputation=args.useRecommendedImputation,
         psd=args.psd, fourierFrequency=args.fourierFrequency,

--- a/accelerometer/summariseEpoch.py
+++ b/accelerometer/summariseEpoch.py
@@ -17,7 +17,7 @@ def getActivitySummary(epochFile, nonWearFile, summary,
     activityClassification=True, timeZone='Europe/London',
     startTime=None, endTime=None,
     epochPeriod=30, stationaryStd=13, minNonWearDuration=60,
-    mgMVPA=100, mgVPA=425,
+    mgCutpointMVPA=100, mgCutpointVPA=425,
     activityModel="activityModels/doherty-may20.tar",
     intensityDistribution=False, useRecommendedImputation=True,
     psd=False, fourierFrequency=False, fourierWithAcc=False, m10l5=False,
@@ -44,8 +44,8 @@ def getActivitySummary(epochFile, nonWearFile, summary,
     :param int epochPeriod: Size of epoch time window (in seconds)
     :param int stationaryStd: Threshold (in mg units) for stationary vs not
     :param int minNonWearDuration: Minimum duration of nonwear events (minutes)
-    :param int mgMVPA: Milli-gravity threshold for moderate intensity activity
-    :param int mgVPA: Milli-gravity threshold for vigorous intensity activity
+    :param int mgCutpointMVPA: Milli-gravity threshold for moderate intensity activity
+    :param int mgCutpointVPA: Milli-gravity threshold for vigorous intensity activity
     :param str activityModel: Input tar model file which contains random forest
         pickle model, HMM priors/transitions/emissions npy files, and npy file
         of METS for each activity state
@@ -128,8 +128,8 @@ def getActivitySummary(epochFile, nonWearFile, summary,
 
     # Calculate imputation values to replace nan PA metric values
     e = perform_wearTime_imputation(e, verbose)
-    e['MVPA'] = e['accImputed'] >= mgMVPA
-    e['VPA'] = e['accImputed'] >= mgVPA
+    e['CutpointMVPA'] = e['accImputed'] >= mgCutpointMVPA
+    e['CutpointVPA'] = e['accImputed'] >= mgCutpointVPA
 
     # Calculate empirical cumulative distribution function of vector magnitudes
     if intensityDistribution:
@@ -402,7 +402,7 @@ def writeMovementSummaries(e, labels, summary, useRecommendedImputation):
     """
 
     # Identify activity types to summarise
-    activityTypes = ['acc', 'MVPA', 'VPA']
+    activityTypes = ['acc', 'CutpointMVPA', 'CutpointVPA']
     activityTypes += labels
     if 'MET' in e.columns:
         activityTypes.append('MET')
@@ -412,7 +412,7 @@ def writeMovementSummaries(e, labels, summary, useRecommendedImputation):
         col = accType
         if useRecommendedImputation:
             col += 'Imputed'
-        if accType in ['MVPA', 'VPA']:
+        if accType in ['CutpointMVPA', 'CutpointVPA']:
             col = accType
 
         # Overall / weekday / weekend summaries

--- a/accelerometer/summariseEpoch.py
+++ b/accelerometer/summariseEpoch.py
@@ -17,7 +17,7 @@ def getActivitySummary(epochFile, nonWearFile, summary,
     activityClassification=True, timeZone='Europe/London',
     startTime=None, endTime=None,
     epochPeriod=30, stationaryStd=13, minNonWearDuration=60,
-    mgCutpointMVPA=100, mgCutpointVPA=425,
+    mgCutPointMVPA=100, mgCutPointVPA=425,
     activityModel="activityModels/doherty-may20.tar",
     intensityDistribution=False, useRecommendedImputation=True,
     psd=False, fourierFrequency=False, fourierWithAcc=False, m10l5=False,
@@ -44,8 +44,8 @@ def getActivitySummary(epochFile, nonWearFile, summary,
     :param int epochPeriod: Size of epoch time window (in seconds)
     :param int stationaryStd: Threshold (in mg units) for stationary vs not
     :param int minNonWearDuration: Minimum duration of nonwear events (minutes)
-    :param int mgCutpointMVPA: Milli-gravity threshold for moderate intensity activity
-    :param int mgCutpointVPA: Milli-gravity threshold for vigorous intensity activity
+    :param int mgCutPointMVPA: Milli-gravity threshold for moderate intensity activity
+    :param int mgCutPointVPA: Milli-gravity threshold for vigorous intensity activity
     :param str activityModel: Input tar model file which contains random forest
         pickle model, HMM priors/transitions/emissions npy files, and npy file
         of METS for each activity state
@@ -128,8 +128,8 @@ def getActivitySummary(epochFile, nonWearFile, summary,
 
     # Calculate imputation values to replace nan PA metric values
     e = perform_wearTime_imputation(e, verbose)
-    e['CutpointMVPA'] = e['accImputed'] >= mgCutpointMVPA
-    e['CutpointVPA'] = e['accImputed'] >= mgCutpointVPA
+    e['CutPointMVPA'] = e['accImputed'] >= mgCutPointMVPA
+    e['CutPointVPA'] = e['accImputed'] >= mgCutPointVPA
 
     # Calculate empirical cumulative distribution function of vector magnitudes
     if intensityDistribution:
@@ -402,7 +402,7 @@ def writeMovementSummaries(e, labels, summary, useRecommendedImputation):
     """
 
     # Identify activity types to summarise
-    activityTypes = ['acc', 'CutpointMVPA', 'CutpointVPA']
+    activityTypes = ['acc', 'CutPointMVPA', 'CutPointVPA']
     activityTypes += labels
     if 'MET' in e.columns:
         activityTypes.append('MET')
@@ -412,7 +412,7 @@ def writeMovementSummaries(e, labels, summary, useRecommendedImputation):
         col = accType
         if useRecommendedImputation:
             col += 'Imputed'
-        if accType in ['CutpointMVPA', 'CutpointVPA']:
+        if accType in ['CutPointMVPA', 'CutPointVPA']:
             col = accType
 
         # Overall / weekday / weekend summaries

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -147,7 +147,7 @@ Then use our python utility function to write processing cmds for all files:
     # if for some reason we wanted to use different thresholds for moderate
     # and vigorous intensity activities, we could go with
     accUtils.writeStudyAccProcessCmds("/myStudy/", "process-cmds.txt", \
-        runName="dec18", cmdOptions="--mgMVPA 90 --mgVPA 435")
+        runName="dec18", cmdOptions="--mgCutPointMVPA 90 --mgCutPointVPA 435")
     # <list of processing commands written to "process-cmds.txt">
 
 Note that if we don't have `files.csv` in the existing directory, the utility function


### PR DESCRIPTION
The aim of this to avoid unexpected overwriting behaviour when either MVPA or VPA appear in the ML-based classes. 