### PR TITLE
change dir structure when process multiple files

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -117,44 +117,45 @@ The above file can be processed as follows:
 Processing multiple files
 *************************
 
-To process multiple files, we recommend the following directory structure be used:
+Suppose we want to process hundreds of accelerometer files:
 ::
-    <studyName>/
-        files.csv #listing all files in rawData directory (optional)
-        rawData/ #all raw .cwa .cwa.gz .bin .gt3x files (no spaces in filename)
-        summary/ #to store outputSummary.json
-        epoch/ #to store feature output for 30sec windows
-        timeSeries/ #simple csv time series output (VMag, activity binary predictions)
-        nonWear/ #bouts of nonwear episodes
-        stationary/ #temp store for features of stationary data for calibration
-        clusterLogs/ #to store terminal output for each processed file
+    studyName/
+        files.csv  # listing files to be processed (optional)
+        subject001.cwa
+        subject002.cwa
+        subject003.cwa
+        ...
 
-This can be created calling our utility script:
-::
-    $ bash utilities/createStudyDir.sh /myStudy/
-
-Next move relevant raw accelerometer files to the rawData folder:
-::
-    $ mv *myAccelerometerFiles.cwa /myStudy/rawData/
-
-Then use our python utility function to write processing cmds for all files:
+We provide a python utility function to facilitate generating the list of
+commands to process each file:
 ::
     from accelerometer import accUtils
-    accUtils.writeStudyAccProcessCmds("/myStudy/", "process-cmds.txt", \
-       runName="dec18")
+    accUtils.writeStudyAccProcessCmds(
+        "myStudy/",
+        outDir="myStudyResults/",
+        cmdsFile="process-cmds.txt"
+    )
     # <list of processing commands written to "process-cmds.txt">
 
-    # if for some reason we wanted to use different thresholds for moderate
+    # If we need to pass arguments to the processing commands, use 'cmdsOptions'
+    # e.g. if for some reason we wanted to use different thresholds for moderate
     # and vigorous intensity activities, we could go with
-    accUtils.writeStudyAccProcessCmds("/myStudy/", "process-cmds.txt", \
-        runName="dec18", cmdOptions="--mgCutPointMVPA 90 --mgCutPointVPA 435")
+    accUtils.writeStudyAccProcessCmds(
+        "myStudy/", 
+        outDir="myStudyResults/", 
+        cmdOptions="--mgCutPointMVPA 90 --mgCutPointVPA 435",
+        cmdsFile="process-cmds.txt",
+    )
     # <list of processing commands written to "process-cmds.txt">
 
-Note that if we don't have `files.csv` in the existing directory, the utility function
-will automatically create a `files.csv` that contains the names of all the files in `rawData/`.
-For this to work, we need to specify which file type to use by setting the `accExt` parameter, e.g.,
-cwa, CWA, bin, BIN, gt3x. We can also directly create our own `files.csv` with a column whose column
-name needs to be 'fileName'.
+In the example above, a `process-cmds.txt` text file is created, listing the
+processing commands for each file listed in `files.csv`. If `files.csv` is
+not present, all the accelerometer files in `myStudy/` will be processed, and
+a `files.csv` will be created in place listing all the files. For
+this to work, we need to specify which file type to use by setting the
+`accExt` parameter, e.g., cwa, CWA, bin, BIN, gt3x. We can also directly
+create our own `files.csv` with a column whose column name needs to be
+'fileName'.
 
 We can then kick-start the processing of all accelerometer files. More advanced
 users will probably want to parallelise the below script using their HPC
@@ -162,14 +163,40 @@ architecture of choice:
 ::
     $ bash process-cmds.txt
 
+The results of the processing are stored in `myStudyResults/`. The output
+directory has the following structure (which is automatically created):
+::
+    myStudyResults/
+        summary/ #to store outputSummary.json
+            subject001-summary.json
+            subject002-summary.json
+            subject003-summary.json
+            ...
+        epoch/ #to store feature output for 30sec windows
+            subject001-epoch.csv
+            subject002-epoch.csv
+            subject003-epoch.csv
+            ...
+        timeSeries/ #simple csv time series output (VMag, activity binary predictions)
+            subject001-timeSeries.csv
+            subject002-timeSeries.csv
+            subject003-timeSeries.csv
+            ...
+        nonWear/ #bouts of nonwear episodes
+            ...
+        stationary/ #temp store for features of stationary data for calibration
+            ...
+        clusterLogs/ #to store terminal output for each processed file
+            ...
+
 Next, using our python utility function, we would like to collate all 
 individual processed .json summary files into a single large csv for subsequent 
 health analses:
 ::
     from accelerometer import accUtils
-    accUtils.collateJSONfilesToSingleCSV("/myStudy/summary/dec18/", \
-        "myStudy/dec18-summary-info.csv")
-    # <summary CSV for all participants written to "/myStudy/dec18-sumamry-info.csv">
+    accUtils.collateJSONfilesToSingleCSV("myStudyResults/summary/", \
+        "myStudyResults/summary-info.csv")
+    # <summary CSV for all participants written to "myStudyResults/sumamry-info.csv">
 
 ===============
 Quality control
@@ -179,9 +206,9 @@ python utility function can write to file all participants' data that was not
 successfully processed:
 ::
     from accelerometer import accUtils
-    accUtils.identifyUnprocessedFiles("/myStudy/files.csv", "myStudy/dec18-summary-info.csv", \
-          "myStudy/files-unprocessed.csv")
-    # <Output CSV listing files to be reprocessed written to "/myStudy/files-unprocessed.csv">
+    accUtils.identifyUnprocessedFiles("myStudy/files.csv", "myStudyResults/summary-info.csv", \
+          "myStudyResults/files-unprocessed.csv")
+    # <Output CSV listing files to be reprocessed written to "myStudyResults/files-unprocessed.csv">
 
 
 On other occasions some participants' data may not have been calibrated properly.
@@ -189,16 +216,16 @@ Our python utility function can assigns the calibration coefs from a previous
 good use of a given device in the same study dataset:
 ::
     from accelerometer import accUtils
-    accUtils.updateCalibrationCoefs("myStudy/dec18-summary-info.csv", \
-           "myStudy/files-recalibration.csv")
-    # <CSV of files to be reprocessed written to "/myStudy/files-recalibration.csv">
+    accUtils.updateCalibrationCoefs("myStudyResults/summary-info.csv", \
+           "myStudyResults/files-recalibration.csv")
+    # <CSV of files to be reprocessed written to "myStudyResults/files-recalibration.csv">
 
 
 Our python utility function can then re-write processing cmds as follows:
 ::
     from accelerometer import accUtils
-    accUtils.writeStudyAccProcessCmds("/myStudy/", "process-cmds-recalibration.txt", \
-       runName="dec18", filesID="files-calibration.csv", cmdOptions="--skipCalibration True")
+    accUtils.writeStudyAccProcessCmds("myStudy/", cmdsFile="process-cmds-recalibration.txt", \
+       outDir="myStudyResults/", filesID="myStudyResults/files-calibration.csv", cmdOptions="--skipCalibration True")
     # <list of processing commands written to "process-cmds-recalibration.txt">
 
 These 'reprocessed' files can then be processed as outlined in the section above.


### PR DESCRIPTION
This is to change the output directory structure when processing multiple files. Currently, the directory structure is:

```
dataset/
    rawData/
        subject001.cwa
        subject002.cwa
        subject003.cwa
        ....
    summary/
        someRunJul20/
            subject001-summary.json
            subject002-summary.json
            subject003-summary.json
            ....
        anotherRunSep20/
            subject001-summary.json
            subject002-summary.json
            subject003-summary.json
            ....
        andAnotherRunOct20/
            subject001-summary.json
            subject002-summary.json
            subject003-summary.json
            ....
        ....
    timeSeries/
        someRunJul20/
            subject001-timeSeries.json
            subject002-timeSeries.json
            subject003-timeSeries.json
            ....
        anotherRunSep20/
            subject001-timeSeries.json
            subject002-timeSeries.json
            subject003-timeSeries.json
            ....
        andAnotherRunSep20/
            subject001-timeSeries.json
            subject002-timeSeries.json
            subject003-timeSeries.json
            ....
        ....
    ....
```

With this PR it changes the directory structure to:

```
dataset/  (READ-ONLY)
    subject001.cwa
    subject002.cwa
    subject003.cwa
    ....


someRunJul20/
    summary/
        subject001-summary.json
        subject002-summary.json
        subject003-summary.json
        ....
    timeSeries/
        subject001-timeSeries.json
        subject002-timeSeries.json
        subject003-timeSeries.json
        ....
    ....


anotherRunSep20/
    summary/
        subject001-summary.json
        subject002-summary.json
        subject003-summary.json
        ....
    timeSeries/
        subject001-timeSeries.json
        subject002-timeSeries.json
        subject003-timeSeries.json
        ....
    ....


andAnotherRunOct20/
    summary/
        subject001-summary.json
        subject002-summary.json
        subject003-summary.json
        ....
    timeSeries/
        subject001-timeSeries.json
        subject002-timeSeries.json
        subject003-timeSeries.json
        ....
    ....
```

The idea is to provide a better separation between the dataset and the processing results. The method in `accUtils.py` that handles this is `writeStudyAccProcessCmds`. Whereas before we would pass something like 
```python
writeStudyAccProcessCmds(
    'path/to/dataset/', 
    runName='someRunJul20', 
    cmdsFile='processCmds-someRunJul20.txt'
)
```

with this PR this will change to something like
```python
writeStudyAccProcessCmds(
    'path/to/dataset/', 
    outDir='path/to/someRunJul20/', 
    cmdsFile='processCmds-someRunJul20.txt'
)
```
that is, instead of providing a `runName`, we provide a path to a directory where to write our results (Internal note: Be sure the output location has enough space. For example, you might want to avoid `$HOME` in a cluster setting). Also, the `path/to/dataset` has to be the actual directory containing the raw files, instead of the directory containing `rawData/`.

#### Dataset split into subfolders

As with UKB we may have:
```
dataset/
    group0/
        subject001.cwa
        subject002.cwa
        subject003.cwa
        ....
    group1/
        subject101.cwa
        subject102.cwa
        subject103.cwa
        ....
    group2/
        subject201.cwa
        subject202.cwa
        subject203.cwa
        ....
    ....
```

Here's one possible way to approach this:
```python
for i in range(n):
    writeStudyAccProcessCmds(
    f'path/to/dataset/group{i}', 
    outDir=f'path/to/outDirJul20Run/group{i}', 
    cmdsFile=f'processCmds-Jul20Run-group{i}.txt'
    )
````
then the output directory structure will be:
```
path/to/outDirJul20Run/
    group0/
        summary/
            subject001-summary.json
            subject002-summary.json
            subject003-summary.json
            ....
        timeSeries/
            subject001-timeSeries.json
            subject002-timeSeries.json
            subject003-timeSeries.json
            ....
        ....
    group1/
        summary/
            subject101-summary.json
            subject102-summary.json
            subject103-summary.json
            ....
        timeSeries/
            subject101-timeSeries.json
            subject102-timeSeries.json
            subject103-timeSeries.json
            ....
        ....
    ....
```

(An alternative directory structure could have been:

```
path/to/outDirJul20Run/
    summary/
        group0/
            subject001-summary.json
            subject002-summary.json
            subject003-summary.json
            ....
        group1/
            subject101-summary.json
            subject102-summary.json
            subject103-summary.json
            ....
        ....
    timeSeries/
        group0/
            subject001-timeSeries.json
            subject002-timeSeries.json
            subject003-timeSeries.json
            ....
        group1/
            subject101-timeSeries.json
            subject102-timeSeries.json
            subject103-timeSeries.json
            ....
        ....
```
but I realized this requires more substantial changes in all the other methods of `accUtils.py`).

#### Some other changes
With this PR the `files.csv` will be assumed to be located in the same level as the raw files. Currently, `files.csv` is one level up:
```
dataset
    files.csv
    rawData
        subject001.cwa
        subject002.cwa
        subject003.cwa
        ....
```
But with this PR the subfolder `rawData` is a bit redundant and is removed, but then `files.csv` is put together with the raw files:
```
dataset
    files.csv
    subject001.cwa
    subject002.cwa
    subject003.cwa
    ....
```

A change in this PR unrelated to the matter above is a small improvement in how `files.csv` is used. Currently, the filenames in `files.csv` are given with their full absolute path. This is changed to just having the filename itself since this is enough.

Internal note: I created `.../ukb/accelerometer/group*/` in the cluster which can be used to test this. The difference is that `.../group*/` contains the raw files instead of `.../group*/rawData/`, and `files.csv` is as mentioned above. These folders are linked to `.../UKBB/`, so there's no true copy going on taking extra storage space.