### PR TITLE
Fix sklearn dependency problem and new tests for python and java builds on macos and linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest numpy scipy pandas sklearn argparse datetime statsmodels
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 #
-#  Make sure we can build the java files properly
+#  Make sure we can build the java and python files across operating systems.
 #
 name: build
 
@@ -11,15 +11,28 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest numpy scipy pandas sklearn argparse datetime statsmodels
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
           
-      - name: Compile Parser
+      - name: Compile Java Parser
         run: javac -cp java/JTransforms-3.1-with-dependencies.jar java/*.java

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
         'numpy',
         'scipy', 
         'pandas>=0.24',
-        'scikit-learn==0.21.2',
+        'scikit-learn>=0.21.2',
         'sphinx',
         'sphinx-rtd-theme',
         'statsmodels',


### PR DESCRIPTION
After much helpful feedback from @angerhang this pull request:

1) Installs correct dependencies so that our accelerometer package now works on OSX again.
2) Updates the testing framework to evaluate Java and python builds on both OSX and Linux

======
This is an update on a previous messy pull request by me. @angerhang provided the below helpful comment in that pull request:

I would be keen for this PR to include a workflow test for the build for both MacOS and Linux so that we know (in the future), this sort of changes will work in a clean environment.

https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions has a good guide to specifying the environment being run.

The two additional tests should be similar to this https://github.com/activityMonitoring/biobankAccelerometerAnalysis/blob/master/.github/workflows/build.yml
with two extra things:

Install the python dependency using the command specified in the README file
Change of the build environments.