### PR TITLE
fix bug in get_clips and get_total_reads

### DIFF
--- a/accelerometer/summariseEpoch.py
+++ b/accelerometer/summariseEpoch.py
@@ -157,11 +157,11 @@ def getActivitySummary(epochFile, nonWearFile, summary,
     return e, labels
 
 def get_clips(e, epochPeriod, summary):
-    summary['clipsBeforeCalibration'] = np.sum(e['clipsBeforeCalibr'])
-    summary['clipsAfterCalibration'] = np.sum(e['clipsAfterCalibr'])
-    
+    summary['clipsBeforeCalibration'] = e['clipsBeforeCalibr'].sum().item()
+    summary['clipsAfterCalibration'] = e['clipsAfterCalibr'].sum().item()
+
 def get_total_reads(e, epochPeriod, summary):
-    summary['totalReads'] = np.sum(e['rawSamples'])
+    summary['totalReads'] = e['rawSamples'].sum().item()
 
 def get_interrupts(e, epochPeriod, summary):
     """Identify if there are interrupts in the data recording


### PR DESCRIPTION
This is to fix https://github.com/activityMonitoring/biobankAccelerometerAnalysis/issues/90
@smallsr encountered the error `TypeError: Object of type int64 is not JSON serializable` when processing his files, happening when the program tries to write out the summary in JSON format. 
For some reason, `json` package can't serialize `np.int64`, but `np.float64` is OK 😕 
The sums in `get_clips` and `get_total_reads` produce `np.float64` type when there are NaNs in the columns (happens when there are interrupts or nonwear), but otherwise are of type `np.int64` and that's when it fails. Our sample cwa file has nonwear and interrupts so the bug didn't manifest. 
A quick fix is to convert to native types using `.item()`