### PR TITLE
avoid error message when epoch folder manually changed 

### DIFF
--- a/accProcess.py
+++ b/accProcess.py
@@ -288,12 +288,17 @@ def main():
 
     # Check if we can write to the output folders
     for path in [
-        args.summaryFolder, args.nonWearFolder, args.epochFolder,
+        args.summaryFolder, args.nonWearFolder,
         args.stationaryFolder, args.timeSeriesFolder,
         args.rawFolder, args.npyFolder, args.outputFolder
     ]:
         assert os.access(path, os.W_OK), (
             f"Either folder '{path}' does not exist "
+            "or you do not have write permission"
+        )
+    if args.processInputFile: 
+        assert os.access(args.epochFolder, os.W_OK), (
+            f"Either folder '{args.epochFolder}' does not exist "
             "or you do not have write permission"
         )
 


### PR DESCRIPTION
When `--processInputFile` is `False`, the epochFolder may be manually changed to a folder with previously processed data. write permissions are not required on this folder (and it is likely they are not available, as this data should not be overwritten). 
This PR should allow this folder to have different permissions in the `--processInputFile False` case.