### PR TITLE
fix bug in interrupts; deprecation; refactor

### DIFF
--- a/accelerometer/summariseEpoch.py
+++ b/accelerometer/summariseEpoch.py
@@ -156,9 +156,13 @@ def getActivitySummary(epochFile, nonWearFile, summary,
     # Return physical activity summary
     return e, labels
 
+
+
 def get_clips(e, epochPeriod, summary):
     summary['clipsBeforeCalibration'] = e['clipsBeforeCalibr'].sum().item()
     summary['clipsAfterCalibration'] = e['clipsAfterCalibr'].sum().item()
+
+
 
 def get_total_reads(e, epochPeriod, summary):
     summary['totalReads'] = e['rawSamples'].sum().item()

--- a/accelerometer/summariseEpoch.py
+++ b/accelerometer/summariseEpoch.py
@@ -163,6 +163,8 @@ def get_clips(e, epochPeriod, summary):
 def get_total_reads(e, epochPeriod, summary):
     summary['totalReads'] = e['rawSamples'].sum().item()
 
+
+
 def get_interrupts(e, epochPeriod, summary):
     """Identify if there are interrupts in the data recording
 
@@ -175,12 +177,9 @@ def get_interrupts(e, epochPeriod, summary):
     """
 
     epochNs = epochPeriod * np.timedelta64(1, 's')
-    interrupts = np.where(e.index.to_series(keep_tz=True).diff() > epochNs)[0]
+    interrupts = np.where(e.index.to_series().diff() > epochNs)[0]
     # Get duration of each interrupt in minutes
-    interruptMins = []
-    for i in interrupts:
-        interruptMins.append(e.index[i-1:i+1].to_series(keep_tz=True).diff() /
-         np.timedelta64(1, 'm'))
+    interruptMins = [e.index[i-1:i+1].to_series().diff().sum(skipna=True).seconds / 60 for i in interrupts]
     # Record to output summary
     summary['errs-interrupts-num'] = len(interruptMins)
     summary['errs-interrupt-mins'] = accUtils.formatNum(np.sum(interruptMins), 1)


### PR DESCRIPTION
This is to fix a bug in `get_interrupts` that results in NaN in `summary['errs-interrupt-mins']`. The problem is that pandas `.diff()` creates a NaN in the first row -- e.g. see these examples https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.diff.html
This makes `summary['errs-interrupt-mins']` always NaN. Apparently no one noticed it so far.
Second, I also removed `keep_tz` flag which is deprecated https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.0.0.html#deprecations
Finally, refactor for consistent spacing between functions.