### PR TITLE
Changes to use scikit-learn 0.24.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ pip3 install --user .
 $ javac -cp java/JTransforms-3.1-with-dependencies.jar java/*.java
 ```
 
-**Note a new dependency was introduced in November 2020. You therefore need to download the updated files to achieve this**.
+**Note a new dependency was introduced in January 2021, making the models compatible with the newest versions of dependency packages. You therefore need to download the updated files to achieve this**.
 ```
 $ git pull
 $ bash utilities/downloadDataModels.sh

--- a/accProcess.py
+++ b/accProcess.py
@@ -170,7 +170,7 @@ def main():
                             activity type
                             (default : %(default)s)""")
     parser.add_argument('--activityModel', type=str,
-                            default="activityModels/walmsley-nov20.tar",
+                            default="activityModels/walmsley-jan21.tar",
                             help="""trained activity model .tar file""")
 
     # circadian rhythm options

--- a/accelerometer/accClassification.py
+++ b/accelerometer/accClassification.py
@@ -6,7 +6,7 @@ import numpy as np
 import os
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
-import sklearn.ensemble.forest as forest
+import sklearn.ensemble._forest as forest
 import sklearn.metrics as metrics
 from sklearn.metrics import confusion_matrix
 import joblib
@@ -312,7 +312,7 @@ def viterbi(observations, states, priors, transitions, emissions,
 
 GLOBAL_INDICES = []
 def _parallel_build_trees(tree, forest, X, y, sample_weight, tree_idx, n_trees,
-                          verbose=0, class_weight=None):
+        verbose=0, class_weight=None, n_samples_bootstrap = None):
     """Monkeypatch scikit learn to use per-class balancing
 
     Private function used to fit a single tree in parallel.

--- a/accelerometer/summariseEpoch.py
+++ b/accelerometer/summariseEpoch.py
@@ -17,7 +17,7 @@ def getActivitySummary(epochFile, nonWearFile, summary,
     startTime=None, endTime=None,
     epochPeriod=30, stationaryStd=13, minNonWearDuration=60,
     mgCutPointMVPA=100, mgCutPointVPA=425,
-    activityModel="activityModels/walmsley-nov20.tar",
+    activityModel="activityModels/walmsley-jan21.tar",
     intensityDistribution=False, useRecommendedImputation=True,
     psd=False, fourierFrequency=False, fourierWithAcc=False, m10l5=False,
     verbose=False):

--- a/utilities/downloadDataModels.sh
+++ b/utilities/downloadDataModels.sh
@@ -14,9 +14,15 @@ fi
 rm activityModels/doherty-may20.tar
 rm activityModels/willetts-may20.tar
 rm activityModels/walmsley-nov20.tar
+rm activityModels/doherty-jan21.tar
+rm activityModels/willetts-jan21.tar
+rm activityModels/walmsley-jan21.tar
 wget ${downloadDir}doherty-may20.tar -P activityModels/
 wget ${downloadDir}willetts-may20.tar -P activityModels/
 wget ${downloadDir}walmsley-nov20.tar -P activityModels/
+wget ${downloadDir}doherty-jan21.tar -P activityModels/
+wget ${downloadDir}willetts-jan21.tar -P activityModels/
+wget ${downloadDir}walmsley-jan21.tar -P activityModels/
 
 # download sample training file
 if ! [ -f "activityModels/labelled-acc-epochs.csv" ]


### PR DESCRIPTION
I think these is the minimal set of changes needed to address Issue #101. 

- imports _forest as private function 
- gives _parallel_build_trees_ an (unused) n_bootstrap_samples argument to match what it is passed from other functions 
- _parallel_build_trees_ does not change at all internally from previous versions of biobankAccelerometerAnalysis. As far as I can tell, this seems compatible with functions in 0.24.0 which call it - but may be risky when working with, and redefining, private functions. 

Feedback very welcome!