### PR TITLE
add to installation instructions; update version to current tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,29 @@ Dependencies include: unix, java 8 ([Java 8 JDK](http://www.oracle.com/technetwo
 ```
 $ git clone https://github.com/activityMonitoring/biobankAccelerometerAnalysis.git
 $ cd biobankAccelerometerAnalysis
-$ bash utilities/downloadDataModels.sh 
-$ pip install --upgrade pip
-$ pip3 install --upgrade -r requirements.txt # Installs a known working set of dependencies, other package versions may also work. 
-$ javac -cp java/JTransforms-3.1-with-dependencies.jar java/*.java
+$ bash utilities/downloadDataModels.sh # Downloads example data and models for behaviour classification
+$ pip install --upgrade pip # Upgrades pip version if required
+$ pip3 install --upgrade -r requirements.txt # Installs a known working set of dependencies, other package versions may also work
+$ javac -cp java/JTransforms-3.1-with-dependencies.jar java/*.java # Compiles Java code
+$ 
+$ # Now to install the package, run: 
+$ pip3 install --user . 
 ```
-**Note a new dependency was introduced in January 2021, making the models compatible with the newest versions of dependency packages. You therefore need to download the updated files to achieve this**.
+Note for developers: If you are actively developing the package, you may wish to skip the installation step.
+
+## Keeping up to date 
+`biobankAccelerometerAnalysis` is regularly updated (e.g. a new dependency was introduced in January 2021, making the models compatible with the newest versions of dependency packages). To install the most recent version with the most recent set of dependencies: 
 ```
 $ git pull
-$ bash utilities/downloadDataModels.sh
-$ pip install --upgrade pip
-$ pip3 install --upgrade -r requirements.txt.
-$ javac -cp java/JTransforms-3.1-with-dependencies.jar java/*.java
+$ cd biobankAccelerometerAnalysis
+$ bash utilities/downloadDataModels.sh # Downloads example data and models for behaviour classification
+$ pip install --upgrade pip # Upgrades pip version if required
+$ pip3 install --upgrade -r requirements.txt # Installs a known working set of dependencies, other package versions may also work
+$ javac -cp java/JTransforms-3.1-with-dependencies.jar java/*.java # Compiles Java code
+$ 
+$ # Now to install the package, run: 
+$ pip3 install --user . 
 ```
-
 
 ## Usage
 To extract a summary of movement (average sample vector magnitude) and

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,18 +9,36 @@
 A tool to extract meaningful health information from large accelerometer datasets. The software generates time-series and summary metrics useful for answering key questions such as how much time is spent in sleep, sedentary behaviour, or doing physical activity.
 
 
-
-************
+*****
 Installation
-************
-Dependancies include: unix, java 8 (`Java 8 JDK <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`_) and python 3.7 (`Anaconda's Python 3 <https://www.anaconda.com/download/>`_ or installation via `Brew <https://docs.python-guide.org/starting/install3/osx/>`_ should do the trick).
+*****
+Dependencies include: unix, java 8 ([Java 8 JDK](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)) and python 3.7 ([Anaconda's Python 3](https://www.anaconda.com/download/) or installation via [Brew](https://docs.python-guide.org/starting/install3/osx/) should do the trick).
 ::
-	$ git clone git@github.com:activityMonitoring/biobankAccelerometerAnalysis.git
-        $ bash utilities/downloadDataModels.sh
-        $ pip install --upgrade pip 
-        $ pip3 install --upgrade -r requirements.txt # Installs a known working set of dependencies, other package versions may also work. 
-        $ javac -cp java/JTransforms-3.1-with-dependencies.jar java/*.java
+	$ git clone https://github.com/activityMonitoring/biobankAccelerometerAnalysis.git
+	$ cd biobankAccelerometerAnalysis
+	$ bash utilities/downloadDataModels.sh # Downloads example data and models for behaviour classification
+	$ pip install --upgrade pip # Upgrades pip version if required
+	$ pip3 install --upgrade -r requirements.txt # Installs a known working set of dependencies, other package versions may also work
+	$ javac -cp java/JTransforms-3.1-with-dependencies.jar java/*.java # Compiles Java code
+	$ 
+	$ # Now to install the package, run: 
+	$ pip3 install --user . 
 
+Note for developers: If you are actively developing the package, you may wish to skip the installation step.
+
+*****
+Keeping up to date
+*****
+`biobankAccelerometerAnalysis` is regularly updated (e.g. a new dependency was introduced in January 2021, making the models compatible with the newest versions of dependency packages). To install the most recent version with the most recent set of dependencies, run (from within the folder): 
+::
+	$ git pull # Pulls any changes
+	$ bash utilities/downloadDataModels.sh # Downloads example data and models for behaviour classification
+	$ pip install --upgrade pip # Upgrades pip version if required
+	$ pip3 install --upgrade -r requirements.txt # Installs a known working set of dependencies, other package versions may also work
+	$ javac -cp java/JTransforms-3.1-with-dependencies.jar java/*.java # Compiles Java code
+	$ 
+	$ # Now to install the package, run: 
+	$ pip3 install --user . 
 
 
 *****

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="accelerometer",
-    version="2.0",
+    version="3.1",
     author="Aiden Doherty",
     author_email="aiden.doherty@bdi.ox.ac.uk",
     description="A package to extract meaningful health information from large accelerometer datasets e.g. how much time individuals spend in sleep, sedentary behaviour, walking and moderate intensity physical activity",


### PR DESCRIPTION
DON'T MERGE YET (Will need to test the agreed installation instructions in a clean environment, so please don't merge just yet!) 

This aims to partially address #146 

If merged, it will: 
- Restore installation via setup.py. This was an omission in recent changes, which meant that users wishing to use the code in "installed package mode" had no instructions. 
- Add a note on what each line of code does in installation (to allow users to flexibly adapt this more easily) 
- Add a note about working with the package for development
- Formalise the note on how to update to the current version
- Update the package version number in `setup.py` installation to match the most recent GitHub version tag (but not automated)

What this doesn't do: 
- Provide a long term solution as to how to manage development-mode vs deployment-mode
- Remove redundancy between `setup.py` and `requirements.txt` (though it is not necessarily desirable to do this https://stackoverflow.com/questions/43658870/requirements-txt-vs-setup-py#:~:text=The%20short%20answer%20is%20that,you%20would%20only%20need%20requirements).
- Automate the interaction between GitHub tag version number and `setup.py` version number
- Do anything to manage the environment for continuous integration and testing
- The instructions are also getting a bit unwieldy - we may need to prune them.

Would love feedback on this! 