### PR TITLE
v4.1.0

### DIFF
--- a/accelerometer/__init__.py
+++ b/accelerometer/__init__.py
@@ -1,5 +1,5 @@
 name = "accelerometer"
-__version__ = "4.0.2"
+__version__ = "4.1.0"
 __author__ = "Aiden Doherty, Shing Chan, Rosemary Walmsley, Hang Yuan, Dan Jackson, Nils Hammerla"
 __email__ = "aiden.doherty@ndph.ox.ac.uk, shing.chan@ndph.ox.ac.uk, rosemary.walmsley@gtc.ox.ac.uk, hang.yuan@keble.ox.ac.uk, dan.jackson@ncl.ac.uk, nils.hammerla@newcastle.ac.uk"
 __license__ = "2-Clause BSD"

--- a/accelerometer/accCollateSummary.py
+++ b/accelerometer/accCollateSummary.py
@@ -1,0 +1,16 @@
+import argparse
+from accelerometer.accUtils import collateSummary
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('resultsDir')
+    parser.add_argument('--outputCsvFile', '-o', default="all-summary.csv")
+    args = parser.parse_args()
+
+    collateSummary(resultsDir=args.resultsDir,
+                   outputCsvFile=args.outputCsvFile)
+
+
+if __name__ == '__main__':
+    main()

--- a/accelerometer/accProcess.py
+++ b/accelerometer/accProcess.py
@@ -328,7 +328,7 @@ def main():  # noqa: C901
     print(f"Processing file '{args.inputFile}' with these arguments:\n")
     for key, value in sorted(vars(args).items()):
         if not (isinstance(value, str) and len(value) == 0):
-            print(key.ljust(15), ':', value)
+            print(key.ljust(25), ':', value)
 
     ##########################
     # Start processing file

--- a/accelerometer/accProcess.py
+++ b/accelerometer/accProcess.py
@@ -311,6 +311,8 @@ def main():  # noqa: C901
             try:
                 if os.path.exists(args.stationaryFile):
                     os.remove(args.stationaryFile)
+                if os.path.exists(args.nonWearFile):
+                    os.remove(args.nonWearFile)
                 if os.path.exists(args.epochFile):
                     os.remove(args.epochFile)
             except OSError:

--- a/accelerometer/accUtils.py
+++ b/accelerometer/accUtils.py
@@ -98,7 +98,7 @@ def toScreen(msg):
     print(f"\n{datetime.datetime.now().strftime(timeFormat)}\t{msg}")
 
 
-def writeCmds(accDir, outDir, cmdsFile='processCmds.txt', accExt="cwa", cmdOptions="", filesCSV="files.csv"):
+def writeCmds(accDir, outDir, cmdsFile='processCmds.txt', accExt="cwa", cmdOptions="", filesCSV=None):
     """Generate a text file listing processing commands for files found under accDir/
 
     :param str accDir: Directory with accelerometer files to process

--- a/accelerometer/accWriteCmds.py
+++ b/accelerometer/accWriteCmds.py
@@ -1,0 +1,23 @@
+import argparse
+from accelerometer.accUtils import writeCmds
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('accDir')
+    parser.add_argument('--outDir', '-d', required=True)
+    parser.add_argument('--cmdsFile', '-f', type=str, default='processCmds.txt')
+    parser.add_argument('--accExt', '-a', default='cwa', help='Acc file type e.g. cwa, CWA, bin, BIN, gt3x...')
+    parser.add_argument('--cmdOptions', '-x', type=str, default="",
+                        help='String of processing options e.g. --epochPeriod 10')
+    args = parser.parse_args()
+
+    writeCmds(accDir=args.accDir,
+              outDir=args.outDir,
+              cmdsFile=args.cmdsFile,
+              accExt=args.accExt,
+              cmdOptions=args.cmdOptions)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,9 @@ setuptools.setup(
     entry_points={
         "console_scripts": [
             "accProcess=accelerometer.accProcess:main",
-            "accPlot=accelerometer.accPlot:main"
+            "accPlot=accelerometer.accPlot:main",
+            "accWriteCmds=accelerometer.accWriteCmds:main",
+            "accCollateSummary=accelerometer.accCollateSummary:main"
         ]
     },
 )


### PR DESCRIPTION
### Major changes in output directory structure
Major change in how outputs are structured: When processing multiple
files, results are now grouped by subjects instead of results. As such,
specifying each folder for each result (e.g. `--timeSeriesFolder timeSeries/`, 
`--summaryFolder summary/`) is now deprecated. 
Instead, simply specify `--outputFolder` and all result files will be stored there. 
The utilities writeCmds() and collateSummary() were also modified accordingly 
to fit the new output structure.

Example:
```
accDir/
    group0/
      subject001.cwa
      subject002.cwa
      ...
    group1/
      subject003.cwa
      subject004.cwa
      ...
```

Then `accUtils.writeCmds('accDir/', 'outDir/')` will result in the following output structure:

```
outDir/
    group0/
      subject001/
        subject001-summary.json
        subject001-timeSeries.csv
        ...
      subject002/
        subject002-summary.json
        subject002-timeSeries.csv
        ...
      ...
    group1/
      subject003/
        subject003-summary.json
        subject003-timeSeries.csv
        ...
      subject004/
        subject004-summary.json
        subject004-timeSeries.csv
        ...
      ...
```

### Two new entry points `accWriteCmds` and `accCollateSummary`

**Usage:**
```bash
accWriteCmds accDir/ -d resultsDir/ -f processCmds.txt
accCollateSummary resultsDir -o all-summary.csv
```
These just call `accUtils.writeCmds` and `accUtils.collateSummary` respectively.

### Minor fixes
- better print
- rm nonWearFile intermediate file at exit
- filesCSV defaults to None (calibrate by default)